### PR TITLE
Added delay to collapse expander when hovering

### DIFF
--- a/packages/makeup-expander/index.js
+++ b/packages/makeup-expander/index.js
@@ -62,6 +62,7 @@ function onHostFocus() {
 }
 
 function onHostHover() {
+  clearTimeout(this._mouseLeft);
   this._expandWasHoverActivated = true;
   this.expanded = true;
 }
@@ -70,8 +71,13 @@ function onFocusExit() {
   this.expanded = false;
 }
 
-function onMouseLeave() {
-  this.expanded = false;
+function onMouseLeave(e) {
+  var _this = this;
+
+  clearTimeout(this._mouseLeft);
+  this._mouseLeft = setTimeout(function () {
+    _this.expanded = false;
+  }, 300);
 }
 
 function _onDocumentClick() {
@@ -255,12 +261,14 @@ module.exports = /*#__PURE__*/function () {
     set: function set(bool) {
       if (bool === true) {
         this.hostEl.addEventListener('mouseenter', this._hostHoverListener);
+        this.contentEl.addEventListener('mouseenter', this._hostHoverListener);
 
         if (this.options.autoCollapse === true) {
           this.collapseOnMouseOut = true;
         }
       } else {
         this.hostEl.removeEventListener('mouseenter', this._hostHoverListener);
+        this.contentEl.removeEventListener('mouseenter', this._hostHoverListener);
       }
     }
   }, {
@@ -292,8 +300,10 @@ module.exports = /*#__PURE__*/function () {
     set: function set(bool) {
       if (bool === true) {
         this.el.addEventListener('mouseleave', this._mouseLeaveListener);
+        this.contentEl.addEventListener('mouseleave', this._mouseLeaveListener);
       } else {
         this.el.removeEventListener('mouseleave', this._mouseLeaveListener);
+        this.contentEl.removeEventListener('mouseleave', this._mouseLeaveListener);
       }
     }
   }, {

--- a/packages/makeup-expander/index.js
+++ b/packages/makeup-expander/index.js
@@ -71,7 +71,7 @@ function onFocusExit() {
   this.expanded = false;
 }
 
-function onMouseLeave(e) {
+function onMouseLeave() {
   var _this = this;
 
   clearTimeout(this._mouseLeft);

--- a/packages/makeup-expander/src/index.js
+++ b/packages/makeup-expander/src/index.js
@@ -52,6 +52,7 @@ function onHostFocus() {
 }
 
 function onHostHover() {
+    clearTimeout(this._mouseLeft);
     this._expandWasHoverActivated = true;
     this.expanded = true;
 }
@@ -60,8 +61,11 @@ function onFocusExit() {
     this.expanded = false;
 }
 
-function onMouseLeave() {
-    this.expanded = false;
+function onMouseLeave(e) {
+    clearTimeout(this._mouseLeft);
+    this._mouseLeft = setTimeout(() => {
+        this.expanded = false;
+    }, 300);
 }
 
 function _onDocumentClick() {
@@ -180,12 +184,14 @@ module.exports = class {
     set expandOnHover(bool) {
         if (bool === true) {
             this.hostEl.addEventListener('mouseenter', this._hostHoverListener);
+            this.contentEl.addEventListener('mouseenter', this._hostHoverListener);
 
             if (this.options.autoCollapse === true) {
                 this.collapseOnMouseOut = true;
             }
         } else {
             this.hostEl.removeEventListener('mouseenter', this._hostHoverListener);
+            this.contentEl.removeEventListener('mouseenter', this._hostHoverListener);
         }
     }
 
@@ -214,8 +220,10 @@ module.exports = class {
     set collapseOnMouseOut(bool) {
         if (bool === true) {
             this.el.addEventListener('mouseleave', this._mouseLeaveListener);
+            this.contentEl.addEventListener('mouseleave', this._mouseLeaveListener);
         } else {
             this.el.removeEventListener('mouseleave', this._mouseLeaveListener);
+            this.contentEl.removeEventListener('mouseleave', this._mouseLeaveListener);
         }
     }
 

--- a/packages/makeup-expander/src/index.js
+++ b/packages/makeup-expander/src/index.js
@@ -61,7 +61,7 @@ function onFocusExit() {
     this.expanded = false;
 }
 
-function onMouseLeave(e) {
+function onMouseLeave() {
     clearTimeout(this._mouseLeft);
     this._mouseLeft = setTimeout(() => {
         this.expanded = false;


### PR DESCRIPTION
This is to fix https://github.com/eBay/ebayui-core/issues/1085

Added a delay to close hover on mouseLeave. Because of this, I had to add event handlers to detect if the mouse was on the popup portion of the hover. Otherwise there was no way to close it when the user leaves the popup. 
I did not use any options because this seems to be a good default case. A possible option would be to increase/decrease the timeout.

Here is the flow
* Host hovers, shows popup
* When mouse leaves, set a timeout for 300ms.
* If in that time the user mouses over on content then clearTimeout
* Otherwise close the popup. 