### PR TITLE
Babel issues fixed, needed Babel's 'useBuiltIns' setting

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -3,5 +3,5 @@
     [
       "@babel/preset-env"
     ]
-  ],
+  ]
 }

--- a/packages/makeup-floating-label/babel.config.json
+++ b/packages/makeup-floating-label/babel.config.json
@@ -1,7 +1,10 @@
 {
   "presets": [
     [
-      "@babel/preset-env"
+      "@babel/preset-env",
+      {
+        "useBuiltIns": "usage"
+      }
     ]
   ],
   "plugins": ["transform-object-assign"]

--- a/packages/makeup-floating-label/index.js
+++ b/packages/makeup-floating-label/index.js
@@ -1,5 +1,17 @@
 'use strict';
 
+require("core-js/modules/es6.object.assign");
+
+require("core-js/modules/es6.object.define-property");
+
+require("core-js/modules/es6.function.bind");
+
+require("core-js/modules/es7.array.includes");
+
+require("core-js/modules/es6.string.includes");
+
+require("core-js/modules/es6.array.is-array");
+
 function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }

--- a/packages/makeup-typeahead/babel.config.json
+++ b/packages/makeup-typeahead/babel.config.json
@@ -1,7 +1,9 @@
 {
     "presets": [
       [
-        "@babel/preset-env"
+        "@babel/preset-env", {
+          "useBuiltIns": "usage"
+        }
       ]
     ]
   }

--- a/packages/makeup-typeahead/index.js
+++ b/packages/makeup-typeahead/index.js
@@ -1,10 +1,12 @@
 'use strict';
 
+require("core-js/modules/es7.array.includes");
+
+require("core-js/modules/es6.string.includes");
+
+require("core-js/modules/es6.string.starts-with");
+
 var findIndex = require('core-js-pure/features/array/find-index');
-
-var startsWith = require('core-js-pure/features/string/starts-with');
-
-var includes = require('core-js-pure/features/string/includes');
 
 function typeahead() {
   var timeout;
@@ -16,12 +18,12 @@ function typeahead() {
     if (nodeList == null) return -1;
     var lowerTypeStr = typeStr.toLocaleLowerCase();
     index = findIndex(nodeList, function (el) {
-      return startsWith(el.innerText.toLocaleLowerCase(), lowerTypeStr);
+      return el.innerText.toLocaleLowerCase().startsWith(lowerTypeStr);
     });
 
     if (index === -1) {
       index = findIndex(nodeList, function (el) {
-        return includes(el.innerText.toLocaleLowerCase(), lowerTypeStr);
+        return el.innerText.toLocaleLowerCase().includes(lowerTypeStr);
       });
     }
 

--- a/packages/makeup-typeahead/package.json
+++ b/packages/makeup-typeahead/package.json
@@ -27,3 +27,4 @@
     "extends @ebay/browserslist-config"
   ]
 }
+

--- a/packages/makeup-typeahead/src/index.js
+++ b/packages/makeup-typeahead/src/index.js
@@ -1,8 +1,6 @@
 'use strict';
 
 const findIndex = require('core-js-pure/features/array/find-index');
-const startsWith = require('core-js-pure/features/string/starts-with');
-const includes = require('core-js-pure/features/string/includes');
 
 function typeahead() {
     let timeout;
@@ -13,9 +11,9 @@ function typeahead() {
         // eslint-disable-next-line eqeqeq
         if (nodeList == null) return -1;
         const lowerTypeStr = typeStr.toLocaleLowerCase();
-        index = findIndex(nodeList, (el) => startsWith(el.innerText.toLocaleLowerCase(), lowerTypeStr));
+        index = findIndex(nodeList, (el) => el.innerText.toLocaleLowerCase().startsWith(lowerTypeStr));
         if (index === -1) {
-            index = findIndex(nodeList, (el) => includes(el.innerText.toLocaleLowerCase(), lowerTypeStr));
+            index = findIndex(nodeList, (el) => el.innerText.toLocaleLowerCase().includes(lowerTypeStr));
         }
         if (timeout) {
             clearTimeout(timeout);


### PR DESCRIPTION
This fixes a couple of issues in makeup-typeahead and makeup-floating-label wrt IE 11 support. 

Because we had not set 'useBuiltIns' in the babel.config.json file, babel was not adding the polyfills / shims from core-js that it should have been adding. 

These changes fix those issues. 