### PR TITLE
refactor[navigation-emitter]: support aria-disabled

### DIFF
--- a/docs/makeup-active-descendant/index.html
+++ b/docs/makeup-active-descendant/index.html
@@ -19,18 +19,20 @@
     <body>
         <main role="main">
             <h1>makeup-active-descendant demo</h1>
-            <p>For the purpose of demonstration, aria-disabled items are greyed out. Hidden items have strike-through.</p>
+            <p>Use ARROW keys to move the active descendant.</p>
+            <p>For the purpose of demonstration, aria-disabled items are greyed out; hidden items have strike-through (in the real world they would obviously be actually hidden). Disabled and hidden items are included in indexing, but skipped in navigation.</p>
 
             <hr />
 
-            <h2>Example 1 - Hierarchical Relationship (default)</h2>
+            <h2>Example 1 - Hierarchical Relationship</h2>
             <div class="widget">
                 <ul role="listbox" tabindex="0">
                     <li role="option">Item 1</li>
-                    <li role="option" aria-disabled="true">Item 2</li>
-                    <li role="option">Item 3</li>
-                    <li role="option" hidden>Item 4</li>
-                    <li role="option">Item 5</li>
+                    <li role="option">Item 2</li>
+                    <li role="option" aria-disabled="true">Item 3</li>
+                    <li role="option">Item 4</li>
+                    <li role="option" hidden>Item 5</li>
+                    <li role="option">Item 6</li>
                 </ul>
             </div>
 
@@ -42,10 +44,11 @@
                 <input type="button" value="button">
                 <ul id="listbox1" role="listbox">
                     <li role="option">Item 1</li>
-                    <li role="option" aria-disabled="true">Item 2</li>
-                    <li role="option">Item 3</li>
-                    <li role="option" hidden>Item 4</li>
-                    <li role="option">Item 5</li>
+                    <li role="option">Item 2</li>
+                    <li role="option" aria-disabled="true">Item 3</li>
+                    <li role="option">Item 4</li>
+                    <li role="option" hidden>Item 5</li>
+                    <li role="option">Item 6</li>
                 </ul>
             </div>
 
@@ -53,8 +56,11 @@
 
             <fieldset>
                 <legend>Tools</legend>
-                <button id="appender">Append New Items</button>
-                <button id="remover">Remove Last Item</button>
+                <button id="prepend">Prepend New Item</button>
+                <button id="append">Append New Item</button>
+                <button id="removeFirst">Remove First Item</button>
+                <button id="removeLast">Remove Last Item</button>
+                <button id="disableCurrent" type="button">Disable Current Item</button>
                 <label>Wrap</label><input id="wrap" type="checkbox">
             </fieldset>
         </main>

--- a/docs/makeup-active-descendant/index.html
+++ b/docs/makeup-active-descendant/index.html
@@ -18,7 +18,7 @@
 
             <hr />
 
-            <h2>Example 1</h2>
+            <h2>Example 1 - Programmatic Relationship</h2>
             <div class="widget">
                 <input type="text" role="combobox" aria-owns="listbox1">
                 <input type="button" value="button">
@@ -31,7 +31,7 @@
 
             <hr />
 
-            <h2>Example 2</h2>
+            <h2>Example 2 - Hierarchical Relationship</h2>
             <div class="widget" data-makeup-init="0" data-makeup-reset="null">
                 <ul role="listbox" tabindex="0">
                     <li role="option">Item 0</li>

--- a/docs/makeup-active-descendant/index.html
+++ b/docs/makeup-active-descendant/index.html
@@ -4,6 +4,9 @@
         <title>makeup-active-descendant demo</title>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <style>
+            li[aria-disabled="true"] {
+                color: lightgrey;
+            }
             li.active-descendant {
                 outline: 1px dotted black;
             }

--- a/docs/makeup-active-descendant/index.html
+++ b/docs/makeup-active-descendant/index.html
@@ -7,6 +7,10 @@
             li[aria-disabled="true"] {
                 color: lightgrey;
             }
+            li[hidden] {
+                display: block;
+                text-decoration: line-through;
+            }
             li.active-descendant {
                 outline: 1px dotted black;
             }
@@ -15,28 +19,33 @@
     <body>
         <main role="main">
             <h1>makeup-active-descendant demo</h1>
+            <p>For the purpose of demonstration, aria-disabled items are greyed out. Hidden items have strike-through.</p>
 
             <hr />
 
-            <h2>Example 1 - Programmatic Relationship</h2>
+            <h2>Example 1 - Hierarchical Relationship (default)</h2>
             <div class="widget">
-                <input type="text" role="combobox" aria-owns="listbox1">
-                <input type="button" value="button">
-                <ul id="listbox1" role="listbox">
-                    <li role="option">Item 0</li>
+                <ul role="listbox" tabindex="0">
                     <li role="option">Item 1</li>
-                    <li role="option">Item 2</li>
+                    <li role="option" aria-disabled="true">Item 2</li>
+                    <li role="option">Item 3</li>
+                    <li role="option" hidden>Item 4</li>
+                    <li role="option">Item 5</li>
                 </ul>
             </div>
 
             <hr />
 
-            <h2>Example 2 - Hierarchical Relationship</h2>
-            <div class="widget" data-makeup-init="0" data-makeup-reset="null">
-                <ul role="listbox" tabindex="0">
-                    <li role="option">Item 0</li>
+            <h2>Example 2 - Programmatic Relationship</h2>
+            <div class="widget">
+                <input type="text" role="combobox" aria-owns="listbox1">
+                <input type="button" value="button">
+                <ul id="listbox1" role="listbox">
                     <li role="option">Item 1</li>
-                    <li role="option">Item 2</li>
+                    <li role="option" aria-disabled="true">Item 2</li>
+                    <li role="option">Item 3</li>
+                    <li role="option" hidden>Item 4</li>
+                    <li role="option">Item 5</li>
                 </ul>
             </div>
 

--- a/docs/makeup-active-descendant/index.js
+++ b/docs/makeup-active-descendant/index.js
@@ -5,13 +5,26 @@
 import * as ActiveDescendant from '../../packages/makeup-active-descendant';
 
 const navs = [];
-const appender = document.getElementById('appender');
-const remover = document.getElementById('remover');
+const append = document.getElementById('append');
+const prepend = document.getElementById('prepend');
+const removeFirst = document.getElementById('removeFirst');
+const removeLast = document.getElementById('removeLast');
 const widgetEls = document.querySelectorAll('.widget');
 const wrapCheckbox = document.getElementById('wrap');
 const log = e => console.log(e.type, e.detail);
 
-appender.addEventListener('click', function() {
+prepend.addEventListener('click', function() {
+    widgetEls.forEach(function(el) {
+        const list = el.querySelector('ul');
+        const newListItem = document.createElement('li');
+        newListItem.setAttribute('role', 'option');
+        const numListItems = parseInt(list.querySelectorAll('li').length, 10);
+        newListItem.innerText = `Item ${numListItems + 1}`;
+        list.insertBefore(newListItem, list.children[0]);
+    });
+});
+
+append.addEventListener('click', function() {
     widgetEls.forEach(function(el) {
         const list = el.querySelector('ul');
         const newListItem = document.createElement('li');
@@ -22,11 +35,25 @@ appender.addEventListener('click', function() {
     });
 });
 
-remover.addEventListener('click', function() {
+removeFirst.addEventListener('click', function() {
+    widgetEls.forEach(function(el) {
+        const list = el.querySelector('ul');
+        const node = list.firstElementChild;
+        list.removeChild(node);
+    });
+});
+
+removeLast.addEventListener('click', function() {
     widgetEls.forEach(function(el) {
         const list = el.querySelector('ul');
         const node = list.lastElementChild;
         list.removeChild(node);
+    });
+});
+
+disableCurrent.addEventListener('click', function() {
+    navs.forEach(function(nav) {
+        if (nav.currentItem) nav.currentItem.setAttribute('aria-disabled', 'true');
     });
 });
 

--- a/docs/makeup-active-descendant/index.js
+++ b/docs/makeup-active-descendant/index.js
@@ -9,6 +9,7 @@ const appender = document.getElementById('appender');
 const remover = document.getElementById('remover');
 const widgetEls = document.querySelectorAll('.widget');
 const wrapCheckbox = document.getElementById('wrap');
+const log = e => console.log(e.type, e.detail);
 
 appender.addEventListener('click', function() {
     widgetEls.forEach(function(el) {
@@ -16,7 +17,7 @@ appender.addEventListener('click', function() {
         const newListItem = document.createElement('li');
         newListItem.setAttribute('role', 'option');
         const numListItems = parseInt(list.querySelectorAll('li').length, 10);
-        newListItem.innerText = `Item ${numListItems}`;
+        newListItem.innerText = `Item ${numListItems + 1}`;
         list.appendChild(newListItem);
     });
 });
@@ -30,32 +31,19 @@ remover.addEventListener('click', function() {
 });
 
 widgetEls.forEach(function(el) {
-    el.addEventListener('activeDescendantChange', function(e) {
-        console.log(e.type, e.detail);
-    });
-
-    const options = {
-        ignoreButtons: true
-    };
-
-    if (el.dataset.makeupInit !== undefined) {
-        options.autoInit = el.dataset.makeupInit;
-    }
-
-    if (el.dataset.makeupReset !== undefined) {
-        if (el.dataset.makeupReset === 'null') {
-            options.autoReset = null;
-        } else {
-            options.autoReset = el.dataset.makeupReset;
-        }
-    }
+    el.addEventListener('activeDescendantInit', log);
+    el.addEventListener('activeDescendantChange', log);
+    el.addEventListener('activeDescendantReset', log);
+    el.addEventListener('activeDescendantMutation', log);
 
     const widget = ActiveDescendant.createLinear(
         el,
         el.querySelector('input') || el.querySelector('ul'),
         el.querySelector('ul'),
         'li',
-        options
+        {
+            nonEmittingElementSelector: 'input[type="button"]'
+        }
     );
 
     navs.push(widget);

--- a/docs/makeup-active-descendant/index.js
+++ b/docs/makeup-active-descendant/index.js
@@ -31,7 +31,7 @@ remover.addEventListener('click', function() {
 
 widgetEls.forEach(function(el) {
     el.addEventListener('activeDescendantChange', function(e) {
-        console.log(e);
+        console.log(e.type, e.detail);
     });
 
     const options = {

--- a/docs/makeup-listbox-button/index.html
+++ b/docs/makeup-listbox-button/index.html
@@ -193,7 +193,7 @@
                     </div>
                 </div>
 
-                <h3>Floating label</h3>
+                <h3>Unselected, with Floating label</h3>
 
                 <div class="listbox-button">
                     <button class="expand-btn expand-btn--floating-label" style="min-width: 175px" aria-expanded="false" aria-haspopup="listbox">
@@ -219,7 +219,7 @@
                                     <use xlink:href="../icon.svg#icon-tick-small"></use>
                                 </svg>
                             </div>
-                            <div class="listbox-button__option" role="option" aria-selected="true">
+                            <div class="listbox-button__option" role="option">
                                 <span class="listbox-button__value">Blue</span>
                                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
                                     <use xlink:href="../icon.svg#icon-tick-small"></use>

--- a/docs/makeup-listbox-button/index.html
+++ b/docs/makeup-listbox-button/index.html
@@ -9,6 +9,9 @@
                 --listbox-button-listbox-background-color: LightYellow;
                 --listbox-option-border-color: LightYellow;
             }
+            div[role=option][aria-disabled="true"] {
+                color: lightgrey;
+            }
         </style>
     </head>
     <body>
@@ -51,7 +54,7 @@
                                     <use xlink:href="../icon.svg#icon-tick-small"></use>
                                 </svg>
                             </div>
-                            <div class="listbox-button__option" role="option">
+                            <div class="listbox-button__option" role="option" aria-disabled="true">
                                 <span class="listbox-button__value">Yellow</span>
                                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
                                     <use xlink:href="../icon.svg#icon-tick-small"></use>
@@ -92,7 +95,7 @@
                                     <use xlink:href="../icon.svg#icon-tick-small"></use>
                                 </svg>
                             </div>
-                            <div class="listbox-button__option" role="option">
+                            <div class="listbox-button__option" role="option" aria-disabled="true">
                                 <span class="listbox-button__value">Yellow</span>
                                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
                                     <use xlink:href="../icon.svg#icon-tick-small"></use>
@@ -136,7 +139,7 @@
                                     <use xlink:href="../icon.svg#icon-tick-small"></use>
                                 </svg>
                             </div>
-                            <div class="listbox-button__option" role="option">
+                            <div class="listbox-button__option" role="option" aria-disabled="true">
                                 <span class="listbox-button__value">Yellow</span>
                                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
                                     <use xlink:href="../icon.svg#icon-tick-small"></use>
@@ -177,7 +180,7 @@
                                     <use xlink:href="../icon.svg#icon-tick-small"></use>
                                 </svg>
                             </div>
-                            <div class="listbox-button__option" role="option">
+                            <div class="listbox-button__option" role="option" aria-disabled="true">
                                 <span class="listbox-button__value">Yellow</span>
                                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
                                     <use xlink:href="../icon.svg#icon-tick-small"></use>
@@ -225,7 +228,7 @@
                                     <use xlink:href="../icon.svg#icon-tick-small"></use>
                                 </svg>
                             </div>
-                            <div class="listbox-button__option" role="option">
+                            <div class="listbox-button__option" role="option" aria-disabled="true">
                                 <span class="listbox-button__value">Yellow</span>
                                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
                                     <use xlink:href="../icon.svg#icon-tick-small"></use>

--- a/docs/makeup-listbox-button/index.js
+++ b/docs/makeup-listbox-button/index.js
@@ -8,18 +8,15 @@ import "@ebay/skin/listbox-button";
 // IMPORT
 import ListboxButton from '../../packages/makeup-listbox-button';
 
+const widgets = [];
+const log = e => console.log(e.type, e.detail);
+
 window.onload = function() {
     document.querySelectorAll('.listbox-button').forEach(function(el, i) {
-        const widget = new ListboxButton(el, {
-            autoSelect: (el.dataset.makeupAutoSelect === 'false') ? false : true
-        });
+        el.addEventListener('makeup-listbox-button-init', log);
+        el.addEventListener('makeup-listbox-button-change', log);
+        el.addEventListener('makeup-listbox-button-mutation', log);
 
-        el.addEventListener('makeup-listbox-button-change', function(e) {
-            console.log(e.type, e.detail);
-        });
-
-        el.addEventListener('makeup-listbox-button-mutation', function(e) {
-            console.log(e.type, e.detail);
-        });
+        widgets.push(new ListboxButton(el, { autoSelect: (el.dataset.makeupAutoSelect === 'false') ? false : true }));
     });
 };

--- a/docs/makeup-listbox/index.html
+++ b/docs/makeup-listbox/index.html
@@ -48,7 +48,7 @@
                                 <use xlink:href="../icon.svg#icon-tick-small"></use>
                             </svg>
                         </div>
-                        <div class="listbox__option" role="option" aria-selected="false">
+                        <div class="listbox__option" role="option" aria-selected="false" aria-disabled="true">
                             <span class="listbox__value">Yellow</span>
                             <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
                                 <use xlink:href="../icon.svg#icon-tick-small"></use>
@@ -60,6 +60,7 @@
                                 <use xlink:href="../icon.svg#icon-tick-small"></use>
                             </svg>
                         </div>
+
                     </div>
                 </div>
 
@@ -79,7 +80,7 @@
                                 <use xlink:href="../icon.svg#icon-tick-small"></use>
                             </svg>
                         </div>
-                        <div class="listbox__option" role="option" aria-selected="false">
+                        <div class="listbox__option" role="option" aria-selected="false" aria-disabled="true">
                             <span class="listbox__value">Yellow</span>
                             <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
                                 <use xlink:href="../icon.svg#icon-tick-small"></use>
@@ -113,7 +114,7 @@
                                 <use xlink:href="../icon.svg#icon-tick-small"></use>
                             </svg>
                         </div>
-                        <div class="listbox__option" role="option" aria-selected="false">
+                        <div class="listbox__option" role="option" aria-selected="false" aria-disabled="true">
                             <span class="listbox__value">Yellow</span>
                             <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
                                 <use xlink:href="../icon.svg#icon-tick-small"></use>
@@ -144,7 +145,7 @@
                                 <use xlink:href="../icon.svg#icon-tick-small"></use>
                             </svg>
                         </div>
-                        <div class="listbox__option" role="option" aria-selected="false">
+                        <div class="listbox__option" role="option" aria-selected="false" aria-disabled="true">
                             <span class="listbox__value">Yellow</span>
                             <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
                                 <use xlink:href="../icon.svg#icon-tick-small"></use>

--- a/docs/makeup-listbox/index.html
+++ b/docs/makeup-listbox/index.html
@@ -13,6 +13,9 @@
                 border: 1px solid black;
                 width: 200px;
             }
+            div[role=option][aria-disabled="true"] {
+                color: lightgrey;
+            }
         </style>
     </head>
     <body>

--- a/docs/makeup-listbox/index.js
+++ b/docs/makeup-listbox/index.js
@@ -7,18 +7,17 @@ import "@ebay/skin/listbox";
 // IMPORT
 import Listbox from '../../packages/makeup-listbox';
 
+const log = e => console.log(e.type, e.detail);
+const widgets = [];
+
 window.onload = function() {
     document.querySelectorAll('.listbox').forEach(function(el, i) {
-        const widget = new Listbox(el, {
-            autoSelect: (el.dataset.makeupAutoSelect === 'false') ? false : true
-        });
+        el.addEventListener('activeDescendantInit', log);
+        el.addEventListener('activeDescendantChange', log);
+        el.addEventListener('makeup-listbox-init', log);
+        el.addEventListener('makeup-listbox-change', log);
+        el.addEventListener('makeup-listbox-mutation', log);
 
-        el.addEventListener('makeup-listbox-change', function(e) {
-            console.log(e.type, e.detail);
-        });
-
-        el.addEventListener('makeup-listbox-mutation', function(e) {
-            console.log(e.type, e.detail);
-        });
+        widgets.push(new Listbox(el, { autoSelect: (el.dataset.makeupAutoSelect === 'false') ? false : true }));
     });
 };

--- a/docs/makeup-menu-button/index.html
+++ b/docs/makeup-menu-button/index.html
@@ -42,6 +42,9 @@
                             <div class="menu-button__item" role="menuitem">
                                 <span>Menu Item 2</span>
                             </div>
+                            <div class="menu-button__item" role="menuitem" aria-disabled="true">
+                                <span>Menu Item 3</span>
+                            </div>
                             <div class="menu-button__item" role="menuitem">
                                 <span>Menu Item 3</span>
                             </div>
@@ -75,8 +78,14 @@
                                     <use xlink:href="../icon.svg#icon-tick-small"></use>
                                 </svg>
                             </div>
-                            <div class="menu-button__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
+                            <div class="menu-button__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort" aria-disabled="true">
                                 <span>Menu Item 3</span>
+                                <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
+                                    <use xlink:href="../icon.svg#icon-tick-small"></use>
+                                </svg>
+                            </div>
+                            <div class="menu-button__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
+                                <span>Menu Item 4</span>
                                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
                                     <use xlink:href="../icon.svg#icon-tick-small"></use>
                                 </svg>
@@ -111,8 +120,14 @@
                                     <use xlink:href="../icon.svg#icon-tick-small"></use>
                                 </svg>
                             </div>
-                            <div class="menu-button__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
+                            <div class="menu-button__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort" aria-disabled="true">
                                 <span>Menu Item 3</span>
+                                <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
+                                    <use xlink:href="../icon.svg#icon-tick-small"></use>
+                                </svg>
+                            </div>
+                            <div class="menu-button__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
+                                <span>Menu Item 4</span>
                                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
                                     <use xlink:href="../icon.svg#icon-tick-small"></use>
                                 </svg>
@@ -146,8 +161,14 @@
                                     <use xlink:href="../icon.svg#icon-tick-small"></use>
                                 </svg>
                             </div>
-                            <div class="menu-button__item" role="menuitemradio" data-makeup-group="sort" aria-checked="false">
+                            <div class="menu-button__item" role="menuitemradio" data-makeup-group="sort" aria-checked="false" aria-disabled="true">
                                 <span>Price</span>
+                                <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
+                                    <use xlink:href="../icon.svg#icon-tick-small"></use>
+                                </svg>
+                            </div>
+                            <div class="menu-button__item" role="menuitemradio" data-makeup-group="sort" aria-checked="false">
+                                <span>Time Left</span>
                                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
                                     <use xlink:href="../icon.svg#icon-tick-small"></use>
                                 </svg>
@@ -182,8 +203,14 @@
                                     <use xlink:href="../icon.svg#icon-tick-small"></use>
                                 </svg>
                             </div>
-                            <div class="menu-button__item" role="menuitemcheckbox" data-makeup-group="filter" aria-checked="false">
+                            <div class="menu-button__item" role="menuitemcheckbox" data-makeup-group="filter" aria-checked="false" aria-disabled="true">
                                 <span>Menu Item 3</span>
+                                <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
+                                    <use xlink:href="../icon.svg#icon-tick-small"></use>
+                                </svg>
+                            </div>
+                            <div class="menu-button__item" role="menuitemcheckbox" data-makeup-group="filter" aria-checked="false">
+                                <span>Menu Item 4</span>
                                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
                                     <use xlink:href="../icon.svg#icon-tick-small"></use>
                                 </svg>
@@ -218,7 +245,7 @@
                                     <use xlink:href="../icon.svg#icon-tick-small"></use>
                                 </svg>
                             </div>
-                            <div class="menu-button__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
+                            <div class="menu-button__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort" aria-disabled="true">
                                 <span>Menu Item B2</span>
                                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
                                     <use xlink:href="../icon.svg#icon-tick-small"></use>

--- a/docs/makeup-menu/index.html
+++ b/docs/makeup-menu/index.html
@@ -14,6 +14,9 @@
                 border: 1px solid black;
                 width: 200px;
             }
+            div[role^=menuitem][aria-disabled="true"] {
+                color: lightgrey;
+            }
         </style>
     </head>
     <body>

--- a/docs/makeup-menu/index.html
+++ b/docs/makeup-menu/index.html
@@ -38,8 +38,11 @@
                         <div class="menu__item" role="menuitem">
                             <span>Item 2</span>
                         </div>
-                        <div class="menu__item" role="menuitem">
+                        <div class="menu__item" role="menuitem" aria-disabled="true">
                             <span>Item 3</span>
+                        </div>
+                        <div class="menu__item" role="menuitem">
+                            <span>Item 4</span>
                         </div>
                     </div>
                 </div>
@@ -60,8 +63,14 @@
                                 <use xlink:href="../icon.svg#icon-tick-small"></use>
                             </svg>
                         </div>
-                        <div class="menu__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
+                        <div class="menu__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort" aria-disabled="true">
                             <span>Item 3</span>
+                            <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
+                                <use xlink:href="../icon.svg#icon-tick-small"></use>
+                            </svg>
+                        </div>
+                        <div class="menu__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
+                            <span>Item 4</span>
                             <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
                                 <use xlink:href="../icon.svg#icon-tick-small"></use>
                             </svg>
@@ -85,8 +94,14 @@
                                 <use xlink:href="../icon.svg#icon-tick-small"></use>
                             </svg>
                         </div>
-                        <div class="menu__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
+                        <div class="menu__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort" aria-disabled="true">
                             <span>Item 3</span>
+                            <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
+                                <use xlink:href="../icon.svg#icon-tick-small"></use>
+                            </svg>
+                        </div>
+                        <div class="menu__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
+                            <span>Item 4</span>
                             <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
                                 <use xlink:href="../icon.svg#icon-tick-small"></use>
                             </svg>
@@ -109,8 +124,14 @@
                                 <use xlink:href="../icon.svg#icon-tick-small"></use>
                             </svg>
                         </div>
-                        <div class="menu__item" role="menuitemcheckbox" aria-checked="false" data-makeup-group="filter">
+                        <div class="menu__item" role="menuitemcheckbox" aria-checked="false" data-makeup-group="filter" aria-disabled="true">
                             <span>Item 3</span>
+                            <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
+                                <use xlink:href="../icon.svg#icon-tick-small"></use>
+                            </svg>
+                        </div>
+                        <div class="menu__item" role="menuitemcheckbox" aria-checked="false" data-makeup-group="filter">
+                            <span>Item 4</span>
                             <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
                                 <use xlink:href="../icon.svg#icon-tick-small"></use>
                             </svg>
@@ -133,7 +154,7 @@
                                 <use xlink:href="../icon.svg#icon-tick-small"></use>
                             </svg>
                         </div>
-                        <div class="menu__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
+                        <div class="menu__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort" aria-disabled="true">
                             <span>Item B2</span>
                             <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
                                 <use xlink:href="../icon.svg#icon-tick-small"></use>

--- a/docs/makeup-menu/index.html
+++ b/docs/makeup-menu/index.html
@@ -73,13 +73,13 @@
 
                 <div class="menu">
                     <div class="menu__items" role="menu">
-                        <div class="menu__item" role="menuitemradio" aria-checked="true" data-makeup-group="sort">
+                        <div class="menu__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
                             <span>Item 1</span>
                             <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
                                 <use xlink:href="../icon.svg#icon-tick-small"></use>
                             </svg>
                         </div>
-                        <div class="menu__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
+                        <div class="menu__item" role="menuitemradio" aria-checked="true" data-makeup-group="sort">
                             <span>Item 2</span>
                             <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
                                 <use xlink:href="../icon.svg#icon-tick-small"></use>
@@ -97,13 +97,13 @@
                 <h2 id="menu-3">Multi-Select</h2>
                 <div class="menu">
                     <div class="menu__items" role="menu">
-                        <div class="menu__item" role="menuitemcheckbox" aria-checked="true" data-makeup-group="filter">
+                        <div class="menu__item" role="menuitemcheckbox" aria-checked="false" data-makeup-group="filter">
                             <span>Item 1</span>
                             <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
                                 <use xlink:href="../icon.svg#icon-tick-small"></use>
                             </svg>
                         </div>
-                        <div class="menu__item" role="menuitemcheckbox" aria-checked="false" data-makeup-group="filter">
+                        <div class="menu__item" role="menuitemcheckbox" aria-checked="true" data-makeup-group="filter">
                             <span>Item 2</span>
                             <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
                                 <use xlink:href="../icon.svg#icon-tick-small"></use>

--- a/docs/makeup-menu/index.js
+++ b/docs/makeup-menu/index.js
@@ -7,20 +7,14 @@ import "@ebay/skin/menu";
 // IMPORT
 import Menu from '../../packages/makeup-menu';
 
+const log = e => console.log(e.type, e.detail);
+
 window.onload = function() {
     document.querySelectorAll('.menu').forEach(function(el, i) {
         const widget = new Menu(el);
 
-        el.addEventListener('makeup-menu-select', function(e) {
-            console.log(e.type, e.detail);
-        });
-
-        el.addEventListener('makeup-menu-change', function(e) {
-            console.log(e.type, e.detail);
-        });
-
-        el.addEventListener('makeup-menu-mutation', function(e) {
-            console.log(e.type, e.detail);
-        });
+        el.addEventListener('makeup-menu-select', log);
+        el.addEventListener('makeup-menu-change', log);
+        el.addEventListener('makeup-menu-mutation', log);
     });
 };

--- a/docs/makeup-navigation-emitter/index.html
+++ b/docs/makeup-navigation-emitter/index.html
@@ -12,42 +12,42 @@
     <body>
         <main role="main">
             <h1>makeup-navigation-emitter demo</h1>
-            <p>Set focus inside on any of the focusable elements, then use ARROW keys to update model.</p>
-            <p><strong>NOTE</strong>: This module does not do any focus management, it only models state, and triggers an event on state change (see developer console for events). So do not expect arrow keys to change focus.</p>
+            <p>Set focus inside on any of the focusable elements, then use ARROW keys to update model (see developer console).</p>
+            <p><strong>NOTE</strong>: Arrow keys DO NOT change focus. This module does not do any focus management, it only models state, and triggers events.</p>
             <p>This module creates the underlying model for <a href="https://github.com/makeup-js/makeup-roving-tabindex">makeup-roving-tabindex</a> and <a href="https://github.com/makeup-js/makeup-active-descendant">makeup-active-descendant</a>. Those modules <em>will</em> change focus on arrow keys. You probably don't need to use this module directly.</p>
 
-            <h2>Example 1 - Roving Tabindex style</h2>
+            <h2>Example 1 - Item-Based Relationship</h2>
             <div class="widget">
                 <ul>
-                    <li tabindex="0">Item 0</li>
-                    <li>Item 1</li>
+                    <li tabindex="0">Item 1</li>
                     <li>Item 2</li>
+                    <li>Item 3</li>
+                    <li>Item 4</li>
+                    <li>Item 5</li>
                 </ul>
-                <label>Index</label>
-                <input type="text" class="console" readonly disabled />
             </div>
 
-            <h2>Example 2 - Activedescendant style</h2>
+            <h2>Example 2 - Container-Based Relationship</h2>
             <div class="widget" tabindex="0">
                 <ul>
-                    <li>Item 0</li>
                     <li>Item 1</li>
                     <li>Item 2</li>
+                    <li>Item 3</li>
+                    <li>Item 4</li>
+                    <li>Item 5</li>
                 </ul>
-                <label>Index</label>
-                <input type="text" class="console" readonly disabled />
             </div>
 
-            <h2>Example 3 - "Owned" Activedescendant style</h2>
+            <h2>Example 3 - External-Based Relationship</h2>
             <div class="widget">
                 <input />
                 <ul>
-                    <li>Item 0</li>
                     <li>Item 1</li>
                     <li>Item 2</li>
+                    <li>Item 3</li>
+                    <li>Item 4</li>
+                    <li>Item 5</li>
                 </ul>
-                <label>Index</label>
-                <input type="text" class="console" readonly disabled />
             </div>
 
             <!--
@@ -59,8 +59,6 @@
                     <li><span>Item 1</span></li>
                     <li><span>Item 2</span></li>
                 </ul>
-                <label>Index</label>
-                <input type="text" class="console" readonly disabled />
             </div>
 
             <h2>Example 2b - Nested</h2>
@@ -70,8 +68,6 @@
                     <li><span>Item 1</span></li>
                     <li><span>Item 2</span></li>
                 </ul>
-                <label>Index</label>
-                <input type="text" class="console" readonly disabled />
             </div>
 
             <h2>Example 3b - Nested</h2>
@@ -82,8 +78,6 @@
                     <li><span>Item 1</span></li>
                     <li><span>Item 2</span></li>
                 </ul>
-                <label>Index</label>
-                <input type="text" class="console" readonly disabled />
             </div>
             -->
 

--- a/docs/makeup-navigation-emitter/index.html
+++ b/docs/makeup-navigation-emitter/index.html
@@ -4,7 +4,9 @@
         <title>makeup-navigation-emitter demo</title>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <style>
-
+            li[aria-disabled="true"] {
+                color: lightgrey;
+            }
         </style>
     </head>
     <body>

--- a/docs/makeup-navigation-emitter/index.html
+++ b/docs/makeup-navigation-emitter/index.html
@@ -7,23 +7,28 @@
             li[aria-disabled="true"] {
                 color: lightgrey;
             }
+            li[hidden] {
+                display: block;
+                text-decoration: line-through;
+            }
         </style>
     </head>
     <body>
         <main role="main">
-            <h1>makeup-navigation-emitter demo</h1>
-            <p>Set focus inside on any of the focusable elements, then use ARROW keys to update model (see developer console).</p>
-            <p><strong>NOTE</strong>: Arrow keys DO NOT change focus. This module does not do any focus management, it only models state, and triggers events.</p>
-            <p>This module creates the underlying model for <a href="https://github.com/makeup-js/makeup-roving-tabindex">makeup-roving-tabindex</a> and <a href="https://github.com/makeup-js/makeup-active-descendant">makeup-active-descendant</a>. Those modules <em>will</em> change focus on arrow keys. You probably don't need to use this module directly.</p>
+            <h1>makeup-(keyboard)-navigation-emitter demo</h1>
+            <p></p><strong>TIP</strong>: open developer console to see events!</p> 
+            <p>This module <strong>does not</strong> do any keyboard focus management, it only models state and triggers events. It is the job of consumers, such as <a href="https://github.com/makeup-js/makeup-roving-tabindex">makeup-roving-tabindex</a> and <a href="https://github.com/makeup-js/makeup-active-descendant">makeup-active-descendant</a> to do focus management based on the model and the events it emits. You probably don't ever need to use this module directly!</p>
+            <p>Set keyboard focus inside on any of the focusable "widgets", then use ARROW keys to update model. For the purpose of demonstration/testing, aria-disabled items are greyed out. Hidden items have strike-through. Disabled and hidden items are included in indexing, but skipped in navigation.</p>
 
             <h2>Example 1 - Item-Based Relationship</h2>
             <div class="widget">
                 <ul>
                     <li tabindex="0">Item 1</li>
                     <li>Item 2</li>
-                    <li>Item 3</li>
+                    <li aria-disabled="true">Item 3</li>
                     <li>Item 4</li>
-                    <li>Item 5</li>
+                    <li hidden>Item 5</li>
+                    <li>Item 6</li>
                 </ul>
             </div>
 
@@ -32,9 +37,10 @@
                 <ul>
                     <li>Item 1</li>
                     <li>Item 2</li>
-                    <li>Item 3</li>
+                    <li aria-disabled="true">Item 3</li>
                     <li>Item 4</li>
-                    <li>Item 5</li>
+                    <li hidden>Item 5</li>
+                    <li>Item 6</li>
                 </ul>
             </div>
 
@@ -44,9 +50,10 @@
                 <ul>
                     <li>Item 1</li>
                     <li>Item 2</li>
-                    <li>Item 3</li>
+                    <li aria-disabled="true">Item 3</li>
                     <li>Item 4</li>
-                    <li>Item 5</li>
+                    <li hidden>Item 5</li>
+                    <li>Item 6</li>
                 </ul>
             </div>
 

--- a/docs/makeup-navigation-emitter/index.js
+++ b/docs/makeup-navigation-emitter/index.js
@@ -7,13 +7,13 @@ import * as NavigationEmitter from '../../packages/makeup-navigation-emitter';
 const emitters = [];
 const appender = document.getElementById('appender');
 const widgetEls = document.querySelectorAll('.widget');
-const consoleEls = document.querySelectorAll('.console');
 const wrapCheckbox = document.getElementById('wrap');
+const log = e => console.log(e.type, e.detail);
 
 const options = [
     { },
-    { autoInit: -1, autoReset: -1 },
-    { autoInit: -1, autoReset: -1 }
+    { autoInit: 'none', autoReset: 'none' },
+    { autoInit: 'none', autoReset: 'none' }
 ];
 
 appender.addEventListener('click', function() {
@@ -26,15 +26,10 @@ appender.addEventListener('click', function() {
 });
 
 widgetEls.forEach(function(el, index) {
-    el.addEventListener('navigationModelInit', function(e) {
-        consoleEls[index].value = e.detail.toIndex;
-    });
-    el.addEventListener('navigationModelChange', function(e) {
-        consoleEls[index].value = e.detail.toIndex;
-    });
-    el.addEventListener('navigationModelReset', function(e) {
-        consoleEls[index].value = e.detail.toIndex;
-    });
+    el.addEventListener('navigationModelInit', log);
+    el.addEventListener('navigationModelChange', log);
+    el.addEventListener('navigationModelReset', log);
+    el.addEventListener('navigationModelMutation', log);
     emitters.push(NavigationEmitter.createLinear(el, 'li', options[index]));
 });
 

--- a/docs/makeup-roving-tabindex/index.html
+++ b/docs/makeup-roving-tabindex/index.html
@@ -4,7 +4,9 @@
         <title>makeup-roving-tabindex demo</title>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <style>
-
+            li[aria-disabled="true"] {
+                color: lightgrey;
+            }
         </style>
     </head>
     <body>

--- a/docs/makeup-roving-tabindex/index.html
+++ b/docs/makeup-roving-tabindex/index.html
@@ -7,26 +7,36 @@
             li[aria-disabled="true"] {
                 color: lightgrey;
             }
+            li[hidden] {
+                display: block;
+                text-decoration: line-through;
+            }
         </style>
     </head>
     <body>
         <main role="main">
             <h1>makeup-roving-tabindex demo</h1>
+            <p>For the purpose of demonstration, aria-disabled items are greyed out. Hidden items have strike-through.</p>
 
             <div class="widget">
                 <ul>
-                    <li>Item 0</li>
                     <li>Item 1</li>
-                    <li>Item 2</li>
+                    <li aria-disabled="true">Item 2</li>
+                    <li>Item 3</li>
+                    <li hidden>Item 4</li>
+                    <li>Item 5</li>
                 </ul>
             </div>
 
             <fieldset>
                 <legend>Tools</legend>
-                <button id="decrementer" type="button">Decrement tabindex</button>
-                <button id="incrementer" type="button">Increment tabindex</button>
-                <button id="appender" type="button">Append New Items</button>
-                <button id="remover" type="button">Remove Last Item</button>
+                <button id="prev" type="button">Prev</button>
+                <button id="next" type="button">Next</button>
+                <button id="prepender" type="button">Prepend New Item</button>
+                <button id="appender" type="button">Append New Item</button>
+                <button id="removeFirst" type="button">Remove First Item</button>
+                <button id="removeLast" type="button">Remove Last Item</button>
+                <button id="removeAll" type="button">Remove All Items</button>
                 <label for="wrap">Wrap</label><input id="wrap" type="checkbox">
             </fieldset>
         </main>

--- a/docs/makeup-roving-tabindex/index.html
+++ b/docs/makeup-roving-tabindex/index.html
@@ -33,13 +33,10 @@
 
             <fieldset>
                 <legend>Tools</legend>
-                <button id="prev" type="button">Prev</button>
-                <button id="next" type="button">Next</button>
                 <button id="prepender" type="button">Prepend New Item</button>
                 <button id="appender" type="button">Append New Item</button>
                 <button id="removeFirst" type="button">Remove First Item</button>
                 <button id="removeLast" type="button">Remove Last Item</button>
-                <!-- <button id="removeAll" type="button">Remove All Items</button> -->
                 <button id="removeCurrent" type="button">Remove Current Item</button>
                 <button id="disableCurrent" type="button">Disable Current Item</button>
                 <button id="hideCurrent" type="button">Hide Current Item</button>

--- a/docs/makeup-roving-tabindex/index.html
+++ b/docs/makeup-roving-tabindex/index.html
@@ -16,15 +16,18 @@
     <body>
         <main role="main">
             <h1>makeup-roving-tabindex demo</h1>
-            <p>For the purpose of demonstration, aria-disabled items are greyed out. Hidden items have strike-through.</p>
+            <p>Use ARROW keys to move the roving tabindex.</p>
+            <p>For the purpose of demonstration, aria-disabled items are greyed out; hidden items have strike-through (in the real world they would obviously be actually hidden). Disabled and hidden items are included in indexing, but skipped in navigation.</p>
 
             <div class="widget">
                 <ul>
                     <li>Item 1</li>
-                    <li aria-disabled="true">Item 2</li>
-                    <li>Item 3</li>
-                    <li hidden>Item 4</li>
-                    <li>Item 5</li>
+                    <li>Item 2</li>
+                    <li aria-disabled="true">Item 3</li>
+                    <li>Item 4</li>
+                    <li hidden>Item 5</li>
+                    <li>Item 6</li>
+
                 </ul>
             </div>
 
@@ -36,7 +39,10 @@
                 <button id="appender" type="button">Append New Item</button>
                 <button id="removeFirst" type="button">Remove First Item</button>
                 <button id="removeLast" type="button">Remove Last Item</button>
-                <button id="removeAll" type="button">Remove All Items</button>
+                <!-- <button id="removeAll" type="button">Remove All Items</button> -->
+                <button id="removeCurrent" type="button">Remove Current Item</button>
+                <button id="disableCurrent" type="button">Disable Current Item</button>
+                <button id="hideCurrent" type="button">Hide Current Item</button>
                 <label for="wrap">Wrap</label><input id="wrap" type="checkbox">
             </fieldset>
         </main>

--- a/docs/makeup-roving-tabindex/index.js
+++ b/docs/makeup-roving-tabindex/index.js
@@ -28,8 +28,6 @@ remover.addEventListener('click', function() {
     });
 });
 
-
-
 incrementer.addEventListener('click', function() {
     widgetEls.forEach(function(el, i) {
         rovers[i].index++;
@@ -46,7 +44,7 @@ widgetEls.forEach(function(el) {
     rovers.push(RovingTabindex.createLinear(el, 'li', { index: 0 }));
 
     el.addEventListener('rovingTabindexChange', function(e) {
-        console.log(e);
+        console.log(e.type, e.detail);
     });
 });
 

--- a/docs/makeup-roving-tabindex/index.js
+++ b/docs/makeup-roving-tabindex/index.js
@@ -49,12 +49,18 @@ removeLast.addEventListener('click', function() {
     });
 });
 
+/*
 removeAll.addEventListener('click', function() {
     widgetEls.forEach(function(el) {
         const ul = el.children[0];
         ul.innerHTML = '';
     });
 });
+*/
+
+removeCurrent.addEventListener('click', () => rovers.forEach(widget => widget.currentItem.remove()));
+disableCurrent.addEventListener('click', () => rovers.forEach(widget => widget.currentItem.setAttribute('aria-disabled', 'true')));
+hideCurrent.addEventListener('click', () => rovers.forEach(widget => widget.currentItem.hidden = true));
 
 next.addEventListener('click', () => widgetEls.forEach((el, i) => rovers[i].next()));
 prev.addEventListener('click', () => widgetEls.forEach((el, i) => rovers[i].previous()));

--- a/docs/makeup-roving-tabindex/index.js
+++ b/docs/makeup-roving-tabindex/index.js
@@ -6,50 +6,65 @@ import * as RovingTabindex from '../../packages/makeup-roving-tabindex';
 
 const rovers = [];
 const appender = document.getElementById('appender');
-const remover = document.getElementById('remover');
-const incrementer = document.getElementById('incrementer');
-const decrementer = document.getElementById('decrementer');
+const prepender = document.getElementById('prepender');
+const removeFirst = document.getElementById('removeFirst');
+const removeLast = document.getElementById('removeLast');
+const removeAll = document.getElementById('removeAll');
+const next = document.getElementById('next');
+const prev = document.getElementById('prev');
 const widgetEls = document.querySelectorAll('.widget');
-const wrapCheckbox = document.getElementById('wrap');
+const wrap = document.getElementById('wrap');
+const log = e => console.log(e.type, e.detail);
 
 appender.addEventListener('click', function() {
     widgetEls.forEach(function(el) {
         const listItem = document.createElement('li');
-        listItem.innerText = `Item ${parseInt(el.querySelectorAll('li').length, 10)}`;
+        listItem.innerText = `Item ${parseInt(el.querySelectorAll('li').length + 1, 10)}`;
         el.children[0].appendChild(listItem);
     });
 });
 
-remover.addEventListener('click', function() {
+prepender.addEventListener('click', function() {
+    widgetEls.forEach(function(el) {
+        const ul = el.children[0];
+        const listItem = document.createElement('li');
+        listItem.innerText = `Item ${parseInt(el.querySelectorAll('li').length + 1, 10)}`;
+        ul.insertBefore(listItem, ul.children[0]);
+    });
+});
+
+removeFirst.addEventListener('click', function() {
+    widgetEls.forEach(function(el) {
+        const ul = el.children[0];
+        const node = ul.firstElementChild;
+        if (node) ul.removeChild(node);
+    });
+});
+
+removeLast.addEventListener('click', function() {
     widgetEls.forEach(function(el) {
         const ul = el.children[0];
         const node = ul.lastElementChild;
-        ul.removeChild(node);
+        if (node) ul.removeChild(node);
     });
 });
 
-incrementer.addEventListener('click', function() {
-    widgetEls.forEach(function(el, i) {
-        rovers[i].index++;
+removeAll.addEventListener('click', function() {
+    widgetEls.forEach(function(el) {
+        const ul = el.children[0];
+        ul.innerHTML = '';
     });
 });
 
-decrementer.addEventListener('click', function() {
-    widgetEls.forEach(function(el, i) {
-        rovers[i].index--;
-    });
-});
+next.addEventListener('click', () => widgetEls.forEach((el, i) => rovers[i].next()));
+prev.addEventListener('click', () => widgetEls.forEach((el, i) => rovers[i].previous()));
+wrap.addEventListener('change', (e) => rovers.forEach((rover) => rover.wrap = e.target.checked));
 
 widgetEls.forEach(function(el) {
-    rovers.push(RovingTabindex.createLinear(el, 'li', { index: 0 }));
+    el.addEventListener('rovingTabindexInit', log);
+    el.addEventListener('rovingTabindexChange', log);
+    el.addEventListener('rovingTabindexMutation', log);
+    el.addEventListener('rovingTabindexReset', log);
 
-    el.addEventListener('rovingTabindexChange', function(e) {
-        console.log(e.type, e.detail);
-    });
-});
-
-wrapCheckbox.addEventListener('change', function(e) {
-    rovers.forEach(function(rover) {
-        rover.wrap = e.target.checked;
-    });
+    rovers.push(RovingTabindex.createLinear(el, 'li'));
 });

--- a/docs/makeup-roving-tabindex/index.js
+++ b/docs/makeup-roving-tabindex/index.js
@@ -9,9 +9,6 @@ const appender = document.getElementById('appender');
 const prepender = document.getElementById('prepender');
 const removeFirst = document.getElementById('removeFirst');
 const removeLast = document.getElementById('removeLast');
-const removeAll = document.getElementById('removeAll');
-const next = document.getElementById('next');
-const prev = document.getElementById('prev');
 const widgetEls = document.querySelectorAll('.widget');
 const wrap = document.getElementById('wrap');
 const log = e => console.log(e.type, e.detail);
@@ -49,21 +46,10 @@ removeLast.addEventListener('click', function() {
     });
 });
 
-/*
-removeAll.addEventListener('click', function() {
-    widgetEls.forEach(function(el) {
-        const ul = el.children[0];
-        ul.innerHTML = '';
-    });
-});
-*/
-
 removeCurrent.addEventListener('click', () => rovers.forEach(widget => widget.currentItem.remove()));
 disableCurrent.addEventListener('click', () => rovers.forEach(widget => widget.currentItem.setAttribute('aria-disabled', 'true')));
 hideCurrent.addEventListener('click', () => rovers.forEach(widget => widget.currentItem.hidden = true));
 
-next.addEventListener('click', () => widgetEls.forEach((el, i) => rovers[i].next()));
-prev.addEventListener('click', () => widgetEls.forEach((el, i) => rovers[i].previous()));
 wrap.addEventListener('change', (e) => rovers.forEach((rover) => rover.wrap = e.target.checked));
 
 widgetEls.forEach(function(el) {

--- a/packages/makeup-active-descendant/README.md
+++ b/packages/makeup-active-descendant/README.md
@@ -169,7 +169,7 @@ Use CSS to style the active descendant however you wish:
     * *number*: specific index position of items (throws error if non-interactive)
 * `autoScroll` : Specify true to scroll the container as activeDescendant changes (default: false)
 * `axis` : specify 'x' for left/right arrow keys, 'y' for up/down arrow keys, or 'both' (default: 'both')
-* `ignoreButtons`: if set to true, nested button elements will not trigger navigationModelChange events. This is useful in a combobox + button scenario, where only the textbox should trigger navigationModelChange events (default: false)
+* `ignoreByDelegateSelector`: CSS selector of descendant elements that will be ignored by the navigation emitters key event delegation (i.e. these elements will *not* operate the active descendant) (default: null)
 
 ## Custom Events
 

--- a/packages/makeup-active-descendant/README.md
+++ b/packages/makeup-active-descendant/README.md
@@ -51,9 +51,9 @@ Markup after instantiation:
 <div class="widget" id="widget-0">
     <input type="text" aria-owns="widget-0-list-0">
     <ul id="widget-0-list-0">
-        <li id="widget-0-item-0" data-makeup-index="0">Item 1</li>
-        <li id="widget-0-item-1" data-makeup-index="1">Item 2</li>
-        <li id="widget-0-item-2" data-makeup-index="2">Item 3</li>
+        <li id="widget-0-item-0">Item 1</li>
+        <li id="widget-0-item-1">Item 2</li>
+        <li id="widget-0-item-2">Item 3</li>
     </ul>
 </div>
 ```
@@ -64,9 +64,9 @@ Markup after pressing down arrow key on focusable element:
 <div class="widget" id="widget-0">
     <input type="text" aria-activedescendant="widget-0-item-0" aria-owns="widget-0-list-0">
     <ul id="widget-0-list-0">
-        <li class="active-descendant" id="widget-0-item-0" data-makeup-index="0">Item 1</li>
-        <li id="widget-0-item-1" data-makeup-index="1">Item 2</li>
-        <li id="widget-0-item-2" data-makeup-index="2">Item 3</li>
+        <li class="active-descendant" id="widget-0-item-0">Item 1</li>
+        <li id="widget-0-item-1">Item 2</li>
+        <li id="widget-0-item-2">Item 3</li>
     </ul>
 </div>
 ```
@@ -123,9 +123,9 @@ Markup after instantiation:
 ```html
 <div class="widget" id="widget-0">
     <ul id="widget-0-list-0" tabindex="0">
-        <li id="widget-0-item-0" data-makeup-index="0">Item 1</li>
-        <li id="widget-0-item-1" data-makeup-index="1">Item 2</li>
-        <li id="widget-0-item-2" data-makeup-index="2">Item 3</li>
+        <li id="widget-0-item-0">Item 1</li>
+        <li id="widget-0-item-1">Item 2</li>
+        <li id="widget-0-item-2">Item 3</li>
     </ul>
 </div>
 ```
@@ -135,9 +135,9 @@ Markup after pressing down arrow key on focusable element:
 ```html
 <div class="widget" id="widget-0">
     <ul id="widget-0-list-0" aria-activedescendant="widget-0-item-0" tabindex="0">
-        <li class="active-descendant" id="widget-0-item-0" data-makeup-index="0">Item 1</li>
-        <li id="widget-0-item-1" data-makeup-index="1">Item 2</li>
-        <li id="widget-0-item-2" data-makeup-index="2">Item 3</li>
+        <li class="active-descendant" id="widget-0-item-0">Item 1</li>
+        <li id="widget-0-item-1">Item 2</li>
+        <li id="widget-0-item-2">Item 3</li>
     </ul>
 </div>
 ```

--- a/packages/makeup-active-descendant/README.md
+++ b/packages/makeup-active-descendant/README.md
@@ -153,15 +153,36 @@ Use CSS to style the active descendant however you wish:
 ## Options
 
 * `activeDescendantClassName`: the HTML class name that will be applied to the ARIA active descendant element (default: 'active-descendant')
-* `autoInit`: specify an integer or -1 for initial index (default: 0) (see [`makeup-navigation-emitter`](https://github.com/makeup-js/makeup-navigation-emitter#options))
-* `autoReset`: specify an integer or -1 for index position when focus exits widget (default: null) (see [`makeup-navigation-emitter`](https://github.com/makeup-js/makeup-navigation-emitter#options))
+* `autoInit`: declares the initial active descendant item (default: "none"). Possible values are:
+    * "none": no index position is set (useful in programmatic active-descendant)
+    * "interactive": first non aria-disabled or hidden element (default)
+    * "ariaChecked": first element with aria-checked=true (useful in ARIA menu)
+    * "ariaSelected": first element with aria-selected=true (useful in ARIA tabs)
+    * "ariaSelectedOrInteractive": first element with aria-selected=true, falling back to "interactive" if not found (useful in ARIA listbox)
+    * *number*: specific index position of items (throws error if non-interactive)
+* `autoReset`: declares the active descendant item after a reset and/or when keyboard focus exits the widget (default: "none"). Possible values are:
+    * "none": no index position is set (useful in programmatic active-descendant)
+    * "current": index remains current (radio button like behaviour)
+    * "interactive": index moves to first non aria-disabled or hidden element
+    * "ariaChecked": index moves to first element with aria-checked=true
+    * "ariaSelected": index moves to first element with aria-selected=true 
+    * *number*: specific index position of items (throws error if non-interactive)
 * `autoScroll` : Specify true to scroll the container as activeDescendant changes (default: false)
 * `axis` : specify 'x' for left/right arrow keys, 'y' for up/down arrow keys, or 'both' (default: 'both')
 * `ignoreButtons`: if set to true, nested button elements will not trigger navigationModelChange events. This is useful in a combobox + button scenario, where only the textbox should trigger navigationModelChange events (default: false)
 
 ## Custom Events
 
+* `activeDescendantInit`
+    * detail
+        * items
+        * fromIndex
+        * toIndex
 * `activeDescendantChange`
+    * detail
+        * fromIndex
+        * toIndex
+* `activeDescendantReset`
     * detail
         * fromIndex
         * toIndex
@@ -171,6 +192,7 @@ Use CSS to style the active descendant however you wish:
 * `navigableItems`: returns navigable subset of matchingItems (e.g. non-hidden & non-disabled items)
 * `index`: the index position of the current active descendant. A no-op on aria-disabled or hidden items.
 * `matchingItems`: returns all items that match item selector
+* `nonEmittingElementSelector`: CSS selector of nested elements that will *not* operate the navigation emitter. This is useful in a combobox + button scenario, where the nested button should not trigger navigationModelChange events (default: null)
 
 ## Methods
 

--- a/packages/makeup-active-descendant/README.md
+++ b/packages/makeup-active-descendant/README.md
@@ -168,9 +168,9 @@ Use CSS to style the active descendant however you wish:
 
 ## Properties
 
-* `filteredItems`: returns filtered items (e.g. non-hidden items)
-* `index`: the index position of the current active descendant
-* `items`: returns all items that match item selector
+* `navigableItems`: returns navigable subset of matchingItems (e.g. non-hidden & non-disabled items)
+* `index`: the index position of the current active descendant. A no-op on aria-disabled or hidden items.
+* `matchingItems`: returns all items that match item selector
 
 ## Methods
 

--- a/packages/makeup-active-descendant/src/index.js
+++ b/packages/makeup-active-descendant/src/index.js
@@ -13,15 +13,15 @@ const defaultOptions = {
 };
 
 function onModelMutation(e) {
-    const options = this._options;
-    const modelIndex = this._navigationEmitter.model.index;
+    const { toIndex } = e.detail;
+    const activeDescendantClassName = this.options.activeDescendantClassName;
 
-    this.matchingItems.forEach(function(item, index) {
+    this.items.forEach(function(item, index) {
         nextID(item);
-        if (index !== modelIndex) {
-            item.classList.remove(options.activeDescendantClassName);
+        if (index !== toIndex) {
+            item.classList.remove(activeDescendantClassName);
         } else {
-            item.classList.add(options.activeDescendantClassName);
+            item.classList.add(activeDescendantClassName);
         }
     });
 
@@ -30,8 +30,8 @@ function onModelMutation(e) {
 
 function onModelChange(e) {
     const { fromIndex, toIndex } = e.detail;
-    const fromItem = this.matchingItems[fromIndex];
-    const toItem = this.matchingItems[toIndex];
+    const fromItem = this.items[fromIndex];
+    const toItem = this.items[toIndex];
 
     if (fromItem) {
         fromItem.classList.remove(this._options.activeDescendantClassName);
@@ -53,12 +53,12 @@ function onModelReset(e) {
     const toIndex = e.detail.toIndex;
     const activeClassName = this._options.activeDescendantClassName;
 
-    this.matchingItems.forEach(function(el) {
+    this.items.forEach(function(el) {
         el.classList.remove(activeClassName);
     });
 
     if (toIndex !== null && toIndex !== -1) {
-        const itemEl = this.matchingItems[toIndex];
+        const itemEl = this.items[toIndex];
         itemEl.classList.add(activeClassName);
         this._focusEl.setAttribute('aria-activedescendant', itemEl.id);
     } else {
@@ -115,7 +115,8 @@ class LinearActiveDescendant extends ActiveDescendant {
         // ensure container has an id
         nextID(this._itemContainerEl);
 
-        if (this.isProgrammaticRelationship === true) {
+        // if programmatic relationship set aria-owns
+        if (this._itemContainerEl !== this._focusEl) {
             focusEl.setAttribute('aria-owns', this._itemContainerEl.id);
         }
 
@@ -123,35 +124,24 @@ class LinearActiveDescendant extends ActiveDescendant {
             autoInit: this._options.autoInit,
             autoReset: this._options.autoReset,
             axis: this._options.axis,
-            nonEmittingElementSelector: this._options.nonEmittingElementSelector,
+            ignoreByDelegateSelector: this._options.ignoreByDelegateSelector,
             wrap: this._options.wrap
         });
 
         // ensure each item has an id
-        this.matchingItems.forEach(function(itemEl) {
+        this.items.forEach(function(itemEl) {
             nextID(itemEl);
         });
     }
 
-    get isProgrammaticRelationship() {
-        return this._itemContainerEl !== this._focusEl;
-    }
-
-    get isHierarchicalRelationship() {
-        return this._itemContainerEl === this._focusEl;
-    }
-
-    // todo: rename or remove
     get index() {
         return this._navigationEmitter.model.index;
     }
 
-    // todo: rename or remove
     set index(newIndex) {
         this._navigationEmitter.model.index = newIndex;
     }
 
-    // todo: rename
     reset() {
         this._navigationEmitter.model.reset();
     }
@@ -160,12 +150,8 @@ class LinearActiveDescendant extends ActiveDescendant {
         return this._navigationEmitter.model.currentItem;
     }
 
-    get navigableItems() {
-        return this._navigationEmitter.model.navigableItems;
-    }
-
-    get matchingItems() {
-        return this._navigationEmitter.model.matchingItems;
+    get items() {
+        return this._navigationEmitter.model.items;
     }
 
     set wrap(newWrap) {

--- a/packages/makeup-active-descendant/test/index.js
+++ b/packages/makeup-active-descendant/test/index.js
@@ -40,12 +40,8 @@ describe('given a list of 3 visible items in programmatic relationship', functio
             testActiveDescendant = ActiveDescendant.createLinear(widgetEl, focusEl, containerEl, 'li'); // eslint-disable-line
         });
 
-        it('module should not be undefined', function() {
-            expect(ActiveDescendant).not.toEqual(undefined);
-        });
-
         it('model should have 3 items', function() {
-            expect(testActiveDescendant.navigableItems.length).toEqual(3);
+            expect(testActiveDescendant.items.length).toEqual(3);
         });
     });
 });
@@ -71,12 +67,8 @@ describe('given a list of 3 visible items in hierarchial relationship', function
             testActiveDescendant = ActiveDescendant.createLinear(widgetEl, focusEl, containerEl, 'li'); // eslint-disable-line
         });
 
-        it('module should not be undefined', function() {
-            expect(ActiveDescendant).not.toEqual(undefined);
-        });
-
         it('model should have 3 items', function() {
-            expect(testActiveDescendant.navigableItems.length).toEqual(3);
+            expect(testActiveDescendant.items.length).toEqual(3);
         });
     });
 });
@@ -103,8 +95,8 @@ describe('given a list of 2 visible items, 1 hidden in programmatic relationship
             testActiveDescendant = ActiveDescendant.createLinear(widgetEl, focusEl, containerEl, 'li'); // eslint-disable-line
         });
 
-        it('model should have 2 items', function() {
-            expect(testActiveDescendant.navigableItems.length).toEqual(2);
+        it('model should have 3 items', function() {
+            expect(testActiveDescendant.items.length).toEqual(3);
         });
     });
 });
@@ -130,8 +122,8 @@ describe('given a list of 2 visible items, 1 hidden in hierarchial relationship'
             testActiveDescendant = ActiveDescendant.createLinear(widgetEl, focusEl, containerEl, 'li'); // eslint-disable-line
         });
 
-        it('model should have 2 items', function() {
-            expect(testActiveDescendant.navigableItems.length).toEqual(2);
+        it('model should have 3 items', function() {
+            expect(testActiveDescendant.items.length).toEqual(3);
         });
     });
 });
@@ -158,8 +150,8 @@ describe('given a list of 3 hidden items in programmatic relationship', function
             testActiveDescendant = ActiveDescendant.createLinear(widgetEl, focusEl, containerEl, 'li'); // eslint-disable-line
         });
 
-        it('model should have 0 items', function() {
-            expect(testActiveDescendant.navigableItems.length).toEqual(0);
+        it('model should have 3 items', function() {
+            expect(testActiveDescendant.items.length).toEqual(3);
         });
     });
 });
@@ -185,57 +177,12 @@ describe('given a list of 3 hidden items in hierarchial relationship', function(
             testActiveDescendant = ActiveDescendant.createLinear(widgetEl, focusEl, containerEl, 'li'); // eslint-disable-line
         });
 
-        it('model should have 0 items', function() {
-            expect(testActiveDescendant.navigableItems.length).toEqual(0);
+        it('model should have 3 items', function() {
+            expect(testActiveDescendant.items.length).toEqual(3);
         });
     });
 });
 /* END STATIC MODEL SIZE TESTS */
-
-/* BEGIN DYNAMIC MODEL SIZE TESTS */
-
-describe('given a list of 3 visible items', function() {
-    beforeAll(function() {
-        document.body.innerHTML = `
-            <div class="widget">
-                <input type="text"/>
-                <ul>
-                    <li>Button 1</li>
-                    <li>Button 2</li>
-                    <li>Button 3</li>
-                </ul>
-            </div>
-        `;
-
-        widgetEl = document.querySelector('.widget');
-        focusEl = widgetEl.querySelector('input');
-        containerEl = widgetEl.querySelector('ul');
-        testActiveDescendant = ActiveDescendant.createLinear(widgetEl, focusEl, containerEl, 'li'); // eslint-disable-line
-    });
-
-    describe('when first item is hidden', function() {
-        beforeAll(function() {
-            testActiveDescendant.matchingItems[0].hidden = true;
-        });
-
-        it('model should have 2 items', function() {
-            expect(testActiveDescendant.navigableItems.length).toEqual(2);
-        });
-    });
-
-    describe('when first item is hidden and then unhidden', function() {
-        beforeAll(function() {
-            testActiveDescendant.matchingItems[0].hidden = true;
-            testActiveDescendant.matchingItems[0].hidden = false;
-        });
-
-        it('model should have 3 items', function() {
-            expect(testActiveDescendant.navigableItems.length).toEqual(3);
-        });
-    });
-});
-
-/* END DYNAMIC MODEL SIZE TESTS */
 
 /* BEGIN ARROW KEY TESTS */
 

--- a/packages/makeup-active-descendant/test/index.js
+++ b/packages/makeup-active-descendant/test/index.js
@@ -23,7 +23,7 @@ describe('given a list of 3 visible items in programmatic relationship', functio
         document.body.innerHTML = `
             <div class="widget">
                 <input type="text"/>
-                <ul class="widget">
+                <ul>
                     <li>Button 1</li>
                     <li>Button 2</li>
                     <li>Button 3</li>
@@ -45,7 +45,7 @@ describe('given a list of 3 visible items in programmatic relationship', functio
         });
 
         it('model should have 3 items', function() {
-            expect(testActiveDescendant.filteredItems.length).toEqual(3);
+            expect(testActiveDescendant.navigableItems.length).toEqual(3);
         });
     });
 });
@@ -54,7 +54,7 @@ describe('given a list of 3 visible items in hierarchial relationship', function
     beforeAll(function() {
         document.body.innerHTML = `
             <div class="widget">
-                <ul class="widget">
+                <ul>
                     <li>Button 1</li>
                     <li>Button 2</li>
                     <li>Button 3</li>
@@ -76,7 +76,7 @@ describe('given a list of 3 visible items in hierarchial relationship', function
         });
 
         it('model should have 3 items', function() {
-            expect(testActiveDescendant.filteredItems.length).toEqual(3);
+            expect(testActiveDescendant.navigableItems.length).toEqual(3);
         });
     });
 });
@@ -86,7 +86,7 @@ describe('given a list of 2 visible items, 1 hidden in programmatic relationship
         document.body.innerHTML = `
             <div class="widget">
                 <input type="text"/>
-                <ul class="widget">
+                <ul>
                     <li>Button 1</li>
                     <li hidden>Button 2</li>
                     <li>Button 3</li>
@@ -104,7 +104,7 @@ describe('given a list of 2 visible items, 1 hidden in programmatic relationship
         });
 
         it('model should have 2 items', function() {
-            expect(testActiveDescendant.filteredItems.length).toEqual(2);
+            expect(testActiveDescendant.navigableItems.length).toEqual(2);
         });
     });
 });
@@ -113,7 +113,7 @@ describe('given a list of 2 visible items, 1 hidden in hierarchial relationship'
     beforeAll(function() {
         document.body.innerHTML = `
             <div class="widget">
-                <ul class="widget">
+                <ul>
                     <li>Button 1</li>
                     <li hidden>Button 2</li>
                     <li>Button 3</li>
@@ -131,7 +131,7 @@ describe('given a list of 2 visible items, 1 hidden in hierarchial relationship'
         });
 
         it('model should have 2 items', function() {
-            expect(testActiveDescendant.filteredItems.length).toEqual(2);
+            expect(testActiveDescendant.navigableItems.length).toEqual(2);
         });
     });
 });
@@ -141,7 +141,7 @@ describe('given a list of 3 hidden items in programmatic relationship', function
         document.body.innerHTML = `
             <div class="widget">
                 <input type="text"/>
-                <ul class="widget">
+                <ul>
                     <li hidden>Button 1</li>
                     <li hidden>Button 2</li>
                     <li hidden>Button 3</li>
@@ -159,7 +159,7 @@ describe('given a list of 3 hidden items in programmatic relationship', function
         });
 
         it('model should have 0 items', function() {
-            expect(testActiveDescendant.filteredItems.length).toEqual(0);
+            expect(testActiveDescendant.navigableItems.length).toEqual(0);
         });
     });
 });
@@ -168,7 +168,7 @@ describe('given a list of 3 hidden items in hierarchial relationship', function(
     beforeAll(function() {
         document.body.innerHTML = `
             <div class="widget">
-                <ul class="widget">
+                <ul>
                     <li hidden>Button 1</li>
                     <li hidden>Button 2</li>
                     <li hidden>Button 3</li>
@@ -186,7 +186,7 @@ describe('given a list of 3 hidden items in hierarchial relationship', function(
         });
 
         it('model should have 0 items', function() {
-            expect(testActiveDescendant.filteredItems.length).toEqual(0);
+            expect(testActiveDescendant.navigableItems.length).toEqual(0);
         });
     });
 });
@@ -199,7 +199,7 @@ describe('given a list of 3 visible items', function() {
         document.body.innerHTML = `
             <div class="widget">
                 <input type="text"/>
-                <ul class="widget">
+                <ul>
                     <li>Button 1</li>
                     <li>Button 2</li>
                     <li>Button 3</li>
@@ -215,22 +215,22 @@ describe('given a list of 3 visible items', function() {
 
     describe('when first item is hidden', function() {
         beforeAll(function() {
-            testActiveDescendant.items[0].hidden = true;
+            testActiveDescendant.matchingItems[0].hidden = true;
         });
 
         it('model should have 2 items', function() {
-            expect(testActiveDescendant.filteredItems.length).toEqual(2);
+            expect(testActiveDescendant.navigableItems.length).toEqual(2);
         });
     });
 
     describe('when first item is hidden and then unhidden', function() {
         beforeAll(function() {
-            testActiveDescendant.items[0].hidden = true;
-            testActiveDescendant.items[0].hidden = false;
+            testActiveDescendant.matchingItems[0].hidden = true;
+            testActiveDescendant.matchingItems[0].hidden = false;
         });
 
         it('model should have 3 items', function() {
-            expect(testActiveDescendant.filteredItems.length).toEqual(3);
+            expect(testActiveDescendant.navigableItems.length).toEqual(3);
         });
     });
 });
@@ -244,7 +244,7 @@ describe('given 3 items with default options in programmatic relationship', func
         document.body.innerHTML = `
             <div class="widget">
                 <input type="text"/>
-                <ul class="widget">
+                <ul>
                     <li>Button 1</li>
                     <li>Button 2</li>
                     <li>Button 3</li>
@@ -354,7 +354,7 @@ describe('given 3 items with default options in hierarchial relationship', funct
     function setup() {
         document.body.innerHTML = `
             <div class="widget">
-                <ul class="widget">
+                <ul>
                     <li>Button 1</li>
                     <li>Button 2</li>
                     <li>Button 3</li>
@@ -469,7 +469,7 @@ describe('given 3 items with autoWrap on', function() {
         document.body.innerHTML = `
             <div class="widget">
                 <input type="text"/>
-                <ul class="widget">
+                <ul>
                     <li>Button 1</li>
                     <li>Button 2</li>
                     <li>Button 3</li>
@@ -495,7 +495,9 @@ describe('given 3 items with autoWrap on', function() {
         });
 
         it('should trigger 1 activeDescendantChange event', function() {
-            expect(onActiveDescendantChange).toHaveBeenCalledTimes(1);
+            setTimeout(function() {
+                expect(onActiveDescendantChange).toHaveBeenCalledTimes(1);
+            }, timeoutInterval);
         });
     });
 
@@ -505,7 +507,9 @@ describe('given 3 items with autoWrap on', function() {
         });
 
         it('should trigger 1 activeDescendantChange event', function() {
-            expect(onActiveDescendantChange).toHaveBeenCalledTimes(1);
+            setTimeout(function() {
+                expect(onActiveDescendantChange).toHaveBeenCalledTimes(1);
+         }, timeoutInterval);
         });
     });
 
@@ -559,7 +563,7 @@ describe('given 3 items with default options', function() {
         document.body.innerHTML = `
             <div class="widget">
                 <input type="text"/>
-                <ul class="widget">
+                <ul>
                     <li>Button 1</li>
                     <li>Button 2</li>
                     <li>Button 3</li>
@@ -619,7 +623,7 @@ describe('given 3 items with axis set to both', function() {
         document.body.innerHTML = `
             <div class="widget">
                 <input type="text"/>
-                <ul class="widget">
+                <ul>
                     <li>Button 1</li>
                     <li>Button 2</li>
                     <li>Button 3</li>
@@ -689,7 +693,7 @@ describe('given 3 items with axis set to x', function() {
         document.body.innerHTML = `
             <div class="widget">
                 <input type="text"/>
-                <ul class="widget">
+                <ul>
                     <li>Button 1</li>
                     <li>Button 2</li>
                     <li>Button 3</li>
@@ -758,7 +762,7 @@ describe('given 3 items with axis set to y', function() {
         document.body.innerHTML = `
             <div class="widget">
                 <input type="text"/>
-                <ul class="widget">
+                <ul>
                     <li>Button 1</li>
                     <li>Button 2</li>
                     <li>Button 3</li>
@@ -831,7 +835,7 @@ describe('given 3 items', function() {
         document.body.innerHTML = `
             <div class="widget">
                 <input type="text"/>
-                <ul class="widget">
+                <ul>
                     <li>Button 1</li>
                     <li>Button 2</li>
                     <li>Button 3</li>
@@ -868,7 +872,9 @@ describe('given 3 items', function() {
 
         it('should set aria-activedescendant to last element child', function() {
             // eslint-disable-next-line max-len
-            expect(focusEl.getAttribute('aria-activedescendant')).toEqual(containerEl.lastElementChild.getAttribute('id'));
+            setTimeout(function() {
+                expect(focusEl.getAttribute('aria-activedescendant')).toEqual(containerEl.lastElementChild.getAttribute('id'));
+            }, timeoutInterval);
         });
     });
 });
@@ -884,7 +890,7 @@ describe('given 3 items', function() {
         document.body.innerHTML = `
             <div class="widget">
                 <input type="text"/>
-                <ul class="widget">
+                <ul>
                     <li>Button 1</li>
                     <li>Button 2</li>
                     <li>Button 3</li>

--- a/packages/makeup-active-descendant/test/index.js
+++ b/packages/makeup-active-descendant/test/index.js
@@ -401,9 +401,11 @@ describe('given 3 items with default options in hierarchial relationship', funct
         });
 
         it('should trigger 1 activeDescendantChange events', function() {
-            expect(onActiveDescendantChange).toHaveBeenCalledTimes(1);
-            // eslint-disable-next-line max-len
-            expect(focusEl.getAttribute('aria-activedescendant')).toEqual(containerEl.firstElementChild.getAttribute('id'));
+            setTimeout(function() {
+                expect(onActiveDescendantChange).toHaveBeenCalledTimes(1);
+                // eslint-disable-next-line max-len
+                expect(focusEl.getAttribute('aria-activedescendant')).toEqual(containerEl.firstElementChild.getAttribute('id'));
+            }, timeoutInterval);
         });
     });
 
@@ -419,11 +421,15 @@ describe('given 3 items with default options in hierarchial relationship', funct
 
     describe('when arrow right is pressed four times', function() {
         beforeAll(function() {
-            triggerArrowKeyPress(widgetEl, 'Right', 4);
+            setTimeout(function() {
+                triggerArrowKeyPress(widgetEl, 'Right', 4);
+            }, timeoutInterval);
         });
 
         it('should trigger 3 activeDescendantChange events', function() {
-            expect(onActiveDescendantChange).toHaveBeenCalledTimes(3);
+            setTimeout(function() {
+                expect(onActiveDescendantChange).toHaveBeenCalledTimes(3);
+            }, timeoutInterval);
         });
     });
 
@@ -857,7 +863,9 @@ describe('given 3 items', function() {
         });
 
         it('should have index value of 0', function() {
-            expect(testActiveDescendant.index).toBe(0);
+            setTimeout(function() {
+                expect(testActiveDescendant.index).toBe(0);
+            }, timeoutInterval);
         });
     });
 
@@ -867,7 +875,9 @@ describe('given 3 items', function() {
         });
 
         it('should have index value of 2', function() {
-            expect(testActiveDescendant.index).toBe(2);
+            setTimeout(function() {
+                expect(testActiveDescendant.index).toBe(2);
+            }, timeoutInterval);
         });
 
         it('should set aria-activedescendant to last element child', function() {
@@ -916,7 +926,9 @@ describe('given 3 items', function() {
         });
 
         it('should have index value of 1', function() {
-            expect(testActiveDescendant.index).toBe(1);
+            setTimeout(function() {
+                expect(testActiveDescendant.index).toBe(1);
+            }, timeoutInterval);
         });
     });
 

--- a/packages/makeup-combobox/src/index.js
+++ b/packages/makeup-combobox/src/index.js
@@ -61,7 +61,7 @@ export default class {
 
     resetFilter() {
         this._listboxWidget._activeDescendant.reset();
-        this._listboxWidget.items.forEach(el => (el.hidden = false));
+        this._listboxWidget.matchingItems.forEach(el => (el.hidden = false));
     }
 
     _observeMutations() {
@@ -151,7 +151,7 @@ function _onTextboxKeyDown(e) {
         e.preventDefault();
         const widget = this;
 
-        this._inputEl.value = nodeListToArray(this._listboxWidget.items).filter(
+        this._inputEl.value = nodeListToArray(this._listboxWidget.navigableItems).filter(
             el => !el.hidden
         )[this._listboxWidget._activeDescendant.index].innerText;
 
@@ -165,7 +165,7 @@ function _onTextboxKeyDown(e) {
                 if (widget._inputEl.value.length === 0) {
                     widget.resetFilter();
                 } else {
-                    _filterSuggestions(widget._inputEl.value, widget._listboxWidget.items);
+                    _filterSuggestions(widget._inputEl.value, widget._listboxWidget.navigableItems);
                 }
             }
         }, this._options.collapseTimeout);
@@ -188,7 +188,7 @@ function _onTextboxInput() {
         if (this._inputEl.value.length === 0) {
             this.resetFilter();
         } else {
-            _filterSuggestions(this._inputEl.value, this._listboxWidget.items);
+            _filterSuggestions(this._inputEl.value, this._listboxWidget.navigableItems);
         }
     }
 }
@@ -199,7 +199,7 @@ function _onListboxClick(e) {
     const indexData = element.dataset.makeupIndex;
 
     if (indexData !== undefined) {
-        this._inputEl.value = nodeListToArray(this._listboxWidget.items).filter(
+        this._inputEl.value = nodeListToArray(this._listboxWidget.navigableItems).filter(
             el => !el.hidden
         )[indexData].innerText;
 
@@ -215,7 +215,7 @@ function _onListboxClick(e) {
 
 function _onListboxActiveDescendantChange(e) {
     if (this._options.autoSelect === true) {
-        this._inputEl.value = nodeListToArray(this._listboxWidget.items).filter(
+        this._inputEl.value = nodeListToArray(this._listboxWidget.navigableItems).filter(
             el => !el.hidden
         )[e.detail.toIndex].innerText;
 

--- a/packages/makeup-combobox/src/index.js
+++ b/packages/makeup-combobox/src/index.js
@@ -1,8 +1,6 @@
 import Expander from 'makeup-expander';
 import Listbox from 'makeup-listbox';
 
-const nodeListToArray = (nodeList) => Array.prototype.slice.call(nodeList);
-
 const defaultOptions = {
     autoSelect: true,
     collapseTimeout: 150,
@@ -61,7 +59,7 @@ export default class {
 
     resetFilter() {
         this._listboxWidget._activeDescendant.reset();
-        this._listboxWidget.matchingItems.forEach(el => (el.hidden = false));
+        this._listboxWidget.items.forEach(el => (el.hidden = false));
     }
 
     _observeMutations() {
@@ -83,8 +81,8 @@ export default class {
     _observeEvents() {
         if (this._destroyed !== true) {
             this._listboxEl.addEventListener('click', this._onListboxClickListener);
-            this._listboxEl.addEventListener(
-                'makeup-listbox-active-descendant-change',
+            this._listboxWidget._activeDescendantRootEl.addEventListener(
+                'activeDescendantChange',
                 this._onListboxActiveDescendantChangeListener
             );
             this._inputEl.addEventListener('focus', this._onInputFocusListener);
@@ -96,8 +94,8 @@ export default class {
 
     _unobserveEvents() {
         this._listboxEl.removeEventListener('click', this._onListboxClickListener);
-        this._listboxEl.removeEventListener(
-            'makeup-listbox-active-descendant-change',
+        this._listboxWidget._activeDescendantRootEl.removeEventListener(
+            'activeDescendantChange',
             this._onListboxActiveDescendantChangeListener
         );
         this._inputEl.removeEventListener('focus', this._onInputFocusListener);
@@ -151,7 +149,7 @@ function _onTextboxKeyDown(e) {
         e.preventDefault();
         const widget = this;
 
-        this._inputEl.value = nodeListToArray(this._listboxWidget.navigableItems).filter(
+        this._inputEl.value = this._listboxWidget.items.filter(
             el => !el.hidden
         )[this._listboxWidget._activeDescendant.index].innerText;
 
@@ -165,7 +163,7 @@ function _onTextboxKeyDown(e) {
                 if (widget._inputEl.value.length === 0) {
                     widget.resetFilter();
                 } else {
-                    _filterSuggestions(widget._inputEl.value, widget._listboxWidget.navigableItems);
+                    _filterSuggestions(widget._inputEl.value, widget._listboxWidget.items);
                 }
             }
         }, this._options.collapseTimeout);
@@ -188,7 +186,7 @@ function _onTextboxInput() {
         if (this._inputEl.value.length === 0) {
             this.resetFilter();
         } else {
-            _filterSuggestions(this._inputEl.value, this._listboxWidget.navigableItems);
+            _filterSuggestions(this._inputEl.value, this._listboxWidget.items);
         }
     }
 }
@@ -199,7 +197,7 @@ function _onListboxClick(e) {
     const indexData = element.dataset.makeupIndex;
 
     if (indexData !== undefined) {
-        this._inputEl.value = nodeListToArray(this._listboxWidget.navigableItems).filter(
+        this._inputEl.value = this._listboxWidget.items.filter(
             el => !el.hidden
         )[indexData].innerText;
 
@@ -215,7 +213,7 @@ function _onListboxClick(e) {
 
 function _onListboxActiveDescendantChange(e) {
     if (this._options.autoSelect === true) {
-        this._inputEl.value = nodeListToArray(this._listboxWidget.navigableItems).filter(
+        this._inputEl.value = this._listboxWidget.items.filter(
             el => !el.hidden
         )[e.detail.toIndex].innerText;
 
@@ -239,11 +237,11 @@ function _filterSuggestions(value, items) {
     const numChars = value.length;
     const currentValue = value.toLowerCase();
 
-    const matchedItems = nodeListToArray(items).filter((el) => {
+    const matchedItems = items.filter((el) => {
         return el.innerText.trim().substring(0, numChars).toLowerCase() === currentValue;
     });
 
-    const unmatchedItems = nodeListToArray(items).filter((el) => {
+    const unmatchedItems = items.filter((el) => {
         return el.innerText.trim().substring(0, numChars).toLowerCase() !== currentValue;
     });
 

--- a/packages/makeup-focusables/test/index.js
+++ b/packages/makeup-focusables/test/index.js
@@ -117,6 +117,7 @@ describe('makeup-focusables', function() {
 
     describe('when it has a callback, should request animation frame and trigger callback', function() {
         beforeAll(function() {
+            jasmine.DEFAULT_TIMEOUT_INTERVAL = 200;
             body.innerHTML = '<div tabindex="1"></div><div></div><div tabindex="2"></div>';
         });
 

--- a/packages/makeup-listbox-button/src/index.js
+++ b/packages/makeup-listbox-button/src/index.js
@@ -37,6 +37,7 @@ export default class {
 
         this.listbox = new Listbox(this._listboxEl, {
             activeDescendantClassName: 'listbox-button__option--active',
+            autoReset: 'ariaSelectedOrInteractive',
             autoSelect: this._options.autoSelect
         });
 

--- a/packages/makeup-listbox/src/index.js
+++ b/packages/makeup-listbox/src/index.js
@@ -116,7 +116,7 @@ export default class {
     }
 
     get index() {
-        return [...this.navigableItems].findIndex((el) => el.getAttribute('aria-selected') === 'true');
+        return [...this.matchingItems].findIndex((el) => el.getAttribute('aria-selected') === 'true');
     }
 
     get navigableItems() {
@@ -130,17 +130,17 @@ export default class {
     select(index) {
         this._unobserveMutations();
 
-        if (_indexInBounds(index, this.navigableItems.length)) {
-            this.navigableItems[index].setAttribute('aria-selected', 'true');
+        if (_indexInBounds(index, this.matchingItems.length)) {
+            this.matchingItems[index].setAttribute('aria-selected', 'true');
 
             if (this._options.useAriaChecked === true) {
-                this.navigableItems[index].setAttribute('aria-checked', 'true');
+                this.matchingItems[index].setAttribute('aria-checked', 'true');
             }
 
             this.el.dispatchEvent(new CustomEvent('makeup-listbox-change', {
                 detail: {
                     optionIndex: index,
-                    optionValue: this.navigableItems[index].innerText
+                    optionValue: this.matchingItems[index].innerText
                 }
             }));
         }
@@ -151,11 +151,11 @@ export default class {
     unselect(index) {
         this._unobserveMutations();
 
-        if (_indexInBounds(index, this.navigableItems.length)) {
-            this.navigableItems[index].setAttribute('aria-selected', 'false');
+        if (_indexInBounds(index, this.matchingItems.length)) {
+            this.matchingItems[index].setAttribute('aria-selected', 'false');
 
             if (this._options.useAriaChecked === true) {
-                this.navigableItems[index].setAttribute('aria-checked', 'false');
+                this.matchingItems[index].setAttribute('aria-checked', 'false');
             }
         }
 
@@ -184,10 +184,10 @@ function _onFocus() {
 
     if (this._mouseDownFlag !== true && this._options.autoSelect === true && this.index === -1) {
         this._activeDescendant.index = 0;
-        this.navigableItems[0].setAttribute('aria-selected', 'true');
+        this.matchingItems[0].setAttribute('aria-selected', 'true');
 
         if (this._options.useAriaChecked === true) {
-            this.navigableItems[0].setAttribute('aria-checked', 'true');
+            this.matchingItems[0].setAttribute('aria-checked', 'true');
         }
     }
     this._mouseDownFlag = false;
@@ -205,7 +205,7 @@ function _onMouseDown() {
 function _onKeyDown(e) {
     if (e.keyCode === 13 || e.keyCode === 32) { // enter key or spacebar key
         const toElIndex = this._activeDescendant.index;
-        const toEl = this.navigableItems[toElIndex];
+        const toEl = this.matchingItems[toElIndex];
         const isTolElSelected = toEl.getAttribute('aria-selected') === 'true';
 
         if (this._options.autoSelect === false && isTolElSelected === false) {
@@ -219,7 +219,7 @@ function _onClick(e) {
     // unlike the keyDown event, the click event target can be a child element of the option
     // e.g. <div role="option"><span>Item 1</span></div>
     const toEl = e.target.closest('[role=option]');
-    const toElIndex = Array.from(this.navigableItems).indexOf(toEl);
+    const toElIndex = Array.from(this.matchingItems).indexOf(toEl);
     const isTolElSelected = toEl.getAttribute('aria-selected') === 'true';
 
     if (this._options.autoSelect === false && isTolElSelected === false) {
@@ -234,8 +234,8 @@ function _onActiveDescendantChange(e) {
     }));
 
     if (this._options.autoSelect === true) {
-        const fromEl = this.navigableItems[e.detail.fromIndex];
-        const toEl = this.navigableItems[e.detail.toIndex];
+        const fromEl = this.matchingItems[e.detail.fromIndex];
+        const toEl = this.matchingItems[e.detail.toIndex];
 
         if (fromEl) {
             this.unselect(e.detail.fromIndex);

--- a/packages/makeup-menu-button/src/index.js
+++ b/packages/makeup-menu-button/src/index.js
@@ -13,7 +13,9 @@ export default class {
         this._options = Object.assign({}, defaultOptions, selectedOptions);
         this.el = widgetEl;
         this._buttonEl = widgetEl.querySelector('button');
-        this.menu = new Menu(widgetEl.querySelector(this._options.menuSelector));
+        this.menu = new Menu(widgetEl.querySelector(this._options.menuSelector), {
+            autoReset: 'interactive'
+        });
         this._buttonPrefix = this._buttonEl.dataset?.makeupMenuButtonPrefix;
         this._buttonTextEl = this._buttonEl.querySelector(defaultOptions.buttonTextSelector);
 

--- a/packages/makeup-menu/src/index.js
+++ b/packages/makeup-menu/src/index.js
@@ -12,9 +12,7 @@ export default class {
         this.el = widgetEl;
 
         this._rovingTabIndex = RovingTabIndex.createLinear(this.el, '[role^=menuitem]', {
-            // todo: what if autoReset index is disabled or hidden?
-            // Leverage navigationEmitter.firstNavigableIndex?
-            autoReset: 0
+            autoReset: 'first'
         });
 
         PreventScrollKeys.add(this.el);

--- a/packages/makeup-menu/src/index.js
+++ b/packages/makeup-menu/src/index.js
@@ -2,7 +2,9 @@ import * as RovingTabIndex from 'makeup-roving-tabindex';
 import * as PreventScrollKeys from 'makeup-prevent-scroll-keys';
 
 const defaultOptions = {
-    customElementMode: false
+    customElementMode: false,
+    autoInit: 'interactive',
+    autoReset: 'interactive'
 };
 
 export default class {
@@ -12,7 +14,8 @@ export default class {
         this.el = widgetEl;
 
         this._rovingTabIndex = RovingTabIndex.createLinear(this.el, '[role^=menuitem]', {
-            autoReset: 'first'
+            autoInit: this._options.autoInit,
+            autoReset: this._options.autoReset
         });
 
         PreventScrollKeys.add(this.el);
@@ -33,7 +36,7 @@ export default class {
     select(index) {
         this._unobserveMutations();
 
-        const el = this.navigableItems[index];
+        const el = this.items[index];
 
         switch (el.getAttribute('role')) {
             case 'menuitemcheckbox':
@@ -50,12 +53,8 @@ export default class {
         this._observeMutations();
     }
 
-    get matchingItems() {
+    get items() {
         return this._rovingTabIndex.matchingItems;
-    }
-
-    get navigableItems() {
-        return this._rovingTabIndex.navigableItems;
     }
 
     get radioGroupNames() {
@@ -133,7 +132,7 @@ function _onKeyDown(e) {
     }
 
     if (e.keyCode === 13 || e.keyCode === 32) {
-        this.select(Array.from(this.navigableItems).indexOf(e.target));
+        this.select(Array.from(this.items).indexOf(e.target));
     }
 
     this._observeMutations();
@@ -143,7 +142,7 @@ function _onClick(e) {
     // unlike the keyDown event, the click event target can be a child element of the menuitem
     // e.g. <div role="menuitem"><span>Item 1</span></div>
     const menuItemEl = e.target.closest('[role^=menuitem]');
-    const index = [...this.navigableItems].indexOf(menuItemEl);
+    const index = this.items.indexOf(menuItemEl);
 
     if (index !== -1) {
         this.select(index);

--- a/packages/makeup-navigation-emitter/README.md
+++ b/packages/makeup-navigation-emitter/README.md
@@ -113,8 +113,8 @@ widgetEl.addEventListener('navigationModelChange', function(e) {
 
 ## Properties
 
-* `items`: returns all items that match item selector
-* `filteredItems`: returns filtered items (e.g. non-hidden items)
+* `matchingItems`: returns all items that match item selector
+* `navigableItems`: returns navigable subset of matchingItems (e.g. non-hidden & non aria-disabled items)
 
 ## Events
 

--- a/packages/makeup-navigation-emitter/README.md
+++ b/packages/makeup-navigation-emitter/README.md
@@ -100,7 +100,7 @@ widgetEl.addEventListener('navigationModelChange', function(e) {
 
 ## Options
 
-* `autoInit`: specify an integer or -1 for initial index position. Can also set to "aria-selected" which will set to index position of first item with `aria-selected=true` (default: 0)
+* `autoInit`: specify an integer or -1 for initial index position. Can also set to "aria-selected" which will set to index position of first item with `aria-selected=true` (default: 'first')
 * `autoReset`: specify an integer or -1 for index position when focus exits widget (default: null)
 * `axis` : specify 'x' for left/right arrow keys, 'y' for up/down arrow keys, or 'both' (default: 'both')
 * `ignoreButtons`: if set to true, nested button elements will not trigger navigationModelChange events. This is useful in a combobox + button scenario, where only the textbox should trigger navigationModelChange events (default: false)

--- a/packages/makeup-navigation-emitter/README.md
+++ b/packages/makeup-navigation-emitter/README.md
@@ -119,7 +119,7 @@ widgetEl.addEventListener('navigationModelChange', function(e) {
     * "ariaSelected": index moves to first element with aria-selected=true
     * *number*: specific index position of items (throws error if non-interactive)
 * `axis` : specify 'x' for left/right arrow keys, 'y' for up/down arrow keys, or 'both' (default: 'both')
-* `nonEmittingElementSelector`: CSS selector of nested elements that will *not* operate the navigation emitter. This is useful in a combobox + button scenario, where the nested button should not trigger navigationModelChange events (default: null)
+* `ignoreByDelegateSelector`: CSS selector of descendant elements that will be ignored by the key event delegation (i.e. these elements will *not* operate the navigation emitter) (default: null)
 * `wrap` : specify whether arrow keys should wrap/loop (default: false)
 
 ## Methods
@@ -137,3 +137,4 @@ widgetEl.addEventListener('navigationModelChange', function(e) {
 * `navigationModelInit` - fired when the model is auto initialised (bubbles: false)
 * `navigationModelChange` - fired when the index is set by any means other than auto init or auto reset (bubbles: false)
 * `navigationModelReset` - fired when the model is auto reset (bubbles: false)
+* `navigationModelMutation` - fired when any changes to the elements DOM (bubbles: false)

--- a/packages/makeup-navigation-emitter/README.md
+++ b/packages/makeup-navigation-emitter/README.md
@@ -100,7 +100,7 @@ widgetEl.addEventListener('navigationModelChange', function(e) {
 
 ## Options
 
-* `autoInit`: specify an integer or -1 for initial index (default: 0)
+* `autoInit`: specify an integer or -1 for initial index position. Can also set to "aria-selected" which will set to index position of first item with `aria-selected=true` (default: 0)
 * `autoReset`: specify an integer or -1 for index position when focus exits widget (default: null)
 * `axis` : specify 'x' for left/right arrow keys, 'y' for up/down arrow keys, or 'both' (default: 'both')
 * `ignoreButtons`: if set to true, nested button elements will not trigger navigationModelChange events. This is useful in a combobox + button scenario, where only the textbox should trigger navigationModelChange events (default: false)
@@ -121,5 +121,3 @@ widgetEl.addEventListener('navigationModelChange', function(e) {
 * `navigationModelInit` - fired when the model is auto initialised
 * `navigationModelChange` - fired when the index is set by any means other than auto init or auto reset
 * `navigationModelReset` - fired when the model is auto reset
-
-For all 3 events, the event detail object contains the `fromIndex` and `toIndex`.

--- a/packages/makeup-navigation-emitter/README.md
+++ b/packages/makeup-navigation-emitter/README.md
@@ -2,17 +2,19 @@
 
 Emits custom `navigationModelChange` event when keyboard navigation keys (e.g ARROW-UP, ARROW-DOWN) occur on given array of elements, their container element or other associated owner.
 
-This module can be used as the underlying logic & state for both roving-tabindex and active-descendant behaviour.
+This module can be used as the underlying logic & state for both roving-tabindex and active-descendant (hierarchical & programmatic) behaviour.
 
 ## Experimental
 
 This module is still in an experimental state; until it reaches v1, all minor releases must be considered as breaking changes.
 
+**NOTE**: All examples below show *abstract* markup examples/structures. In an effort to make clear what this module does and does not do, all examples **do not** include ARIA roles, state or properties. 
+
 ## Example 1
 
 Example support for a roving tab-index model of keyboard navigation (typical of menu and tabs patterns). The list items form a one-dimensional model of navigation.
 
-With keyboard focus on any list item element, arrow keys will update the underlying model.
+With keyboard focus on any list item element, arrow keys will update the underlying index position in relation to the list of items.
 
 **NOTE:** this module will not actually modify the DOM or change any keyboard focus, that is the job of an observer such as makeup-roving-tabindex (which consumes this module).
 
@@ -41,9 +43,11 @@ widgetEl.addEventListener('navigationModelChange', function(e) {
 
 ## Example 2
 
-Example support for an active descendant model of navigation with keyboard focus on ancestor of items (typical of listbox pattern). Again, the list items form a one-dimensional model of navigation.
+Example support for an active descendant model of navigation with keyboard focus on ancestor of items (typical of listbox pattern).
 
-With keyboard focus on the widget, arrow keys will update the underlying model.
+With keyboard focus on the widget, arrow keys will update the underlying index position in relation to the list of items.
+
+Note that this module will not highlight the active item, that is the job of an observer such as makeup-active-descendant.
 
 ```html
 <div class="widget" tabindex="0">
@@ -60,7 +64,7 @@ import NavigationEmitter from 'makeup-navigation-emitter';
 
 const widgetEl = document.querySelector('.widget');
 
-var emitter = NavigationEmitter.createLinear(widgetEl, 'li', { autoInit: -1, autoReset: -1 }));
+var emitter = NavigationEmitter.createLinear(widgetEl, 'li'));
 
 widgetEl.addEventListener('navigationModelChange', function(e) {
     console.log(e.detail.fromIndex, e.detail.toIndex);
@@ -69,9 +73,9 @@ widgetEl.addEventListener('navigationModelChange', function(e) {
 
 ## Example 3
 
-Example support for an active descendant model of navigation with focus on non-ancestor of items (typical of combobox pattern). Once more, the list elements form the one-dimensional model.
+Example support for an active descendant model of navigation with keyboard focus on non-ancestor of items (typical of combobox pattern).
 
-With keyboard focus on the textbox, arrow keys will update the underlying model.
+With keyboard focus on the textbox, arrow keys will update the underlying index position in relation to the list of items.
 
 Note that this module will not highlight the active item, that is the job of an observer such as makeup-active-descendant.
 
@@ -91,7 +95,7 @@ import NavigationEmitter from 'makeup-navigation-emitter';
 
 const widgetEl = document.querySelector('.widget');
 
-var emitter = NavigationEmitter.createLinear(widgetEl, 'li', { autoInit: -1, autoReset: -1 }));
+var emitter = NavigationEmitter.createLinear(widgetEl, 'li', { autoInit: 'none', autoReset: 'none' }));
 
 widgetEl.addEventListener('navigationModelChange', function(e) {
     console.log(e.detail.fromIndex, e.detail.toIndex);
@@ -100,10 +104,22 @@ widgetEl.addEventListener('navigationModelChange', function(e) {
 
 ## Options
 
-* `autoInit`: specify an integer or -1 for initial index position. Can also set to "aria-selected" which will set to index position of first item with `aria-selected=true` (default: 'first')
-* `autoReset`: specify an integer or -1 for index position when focus exits widget (default: null)
+* `autoInit`: declares the initial item (default: "interactive"). Possible values are:
+    * "none": no index position is set (useful in programmatic active-descendant)
+    * "interactive": first non aria-disabled or hidden element (default)
+    * "ariaChecked": first element with aria-checked=true (useful in ARIA menu)
+    * "ariaSelected": first element with aria-selected=true (useful in ARIA tabs)
+    * "ariaSelectedOrInteractive": first element with aria-selected=true, falling back to "interactive" if not found (useful in ARIA listbox)
+    * *number*: specific index position of items (throws error if non-interactive)
+* `autoReset`: declares the item after a reset and/or when keyboard focus exits the widget (default: "current"). Possible values are:
+    * "none": no index position is set (useful in programmatic active-descendant)
+    * "current": index remains current (radio button like behaviour)
+    * "interactive": index moves to first non aria-disabled or hidden element
+    * "ariaChecked": index moves to first element with aria-checked=true
+    * "ariaSelected": index moves to first element with aria-selected=true
+    * *number*: specific index position of items (throws error if non-interactive)
 * `axis` : specify 'x' for left/right arrow keys, 'y' for up/down arrow keys, or 'both' (default: 'both')
-* `ignoreButtons`: if set to true, nested button elements will not trigger navigationModelChange events. This is useful in a combobox + button scenario, where only the textbox should trigger navigationModelChange events (default: false)
+* `nonEmittingElementSelector`: CSS selector of nested elements that will *not* operate the navigation emitter. This is useful in a combobox + button scenario, where the nested button should not trigger navigationModelChange events (default: null)
 * `wrap` : specify whether arrow keys should wrap/loop (default: false)
 
 ## Methods
@@ -118,6 +134,6 @@ widgetEl.addEventListener('navigationModelChange', function(e) {
 
 ## Events
 
-* `navigationModelInit` - fired when the model is auto initialised
-* `navigationModelChange` - fired when the index is set by any means other than auto init or auto reset
-* `navigationModelReset` - fired when the model is auto reset
+* `navigationModelInit` - fired when the model is auto initialised (bubbles: false)
+* `navigationModelChange` - fired when the index is set by any means other than auto init or auto reset (bubbles: false)
+* `navigationModelReset` - fired when the model is auto reset (bubbles: false)

--- a/packages/makeup-navigation-emitter/test/index.js
+++ b/packages/makeup-navigation-emitter/test/index.js
@@ -712,7 +712,9 @@ describe('given 3 items', function() {
         });
 
         it('should trigger navigationModelInit event', function() {
-            expect(onNavigationModelInit).toHaveBeenCalledTimes(1);
+            setTimeout(function() { 
+                expect(onNavigationModelInit).toHaveBeenCalledTimes(1);
+            }, timeoutInterval);
         });
 
         it('should have index value of null', function() {

--- a/packages/makeup-navigation-emitter/test/index.js
+++ b/packages/makeup-navigation-emitter/test/index.js
@@ -6,7 +6,8 @@ var testEl,
     testEmitter,
     onNavigationModelChange,
     onNavigationModelInit,
-    onNavigationModelReset;
+    onNavigationModelReset,
+    onNavigationModelMutation;
 
 function triggerArrowKeyPress(el, dir, num) {
     for(let i = 0; i < num; i++) {
@@ -38,11 +39,7 @@ describe('given a list of 3 visible items', function() {
         });
 
         it('model should have 3 matching items', function() {
-            expect(testEmitter.model.matchingItems.length).toEqual(3);
-        });
-
-        it('model should have 3 navigable items', function() {
-            expect(testEmitter.model.navigableItems.length).toEqual(3);
+            expect(testEmitter.model.items.length).toEqual(3);
         });
     });
 });
@@ -64,12 +61,8 @@ describe('given a list of 3 items with 1 hidden', function() {
             testEmitter = NavigationEmitter.createLinear(testEl, 'li'); // eslint-disable-line
         });
 
-        it('model should have 3 matching items', function() {
-            expect(testEmitter.model.matchingItems.length).toEqual(3);
-        });
-
-        it('model should have 2 navigable items', function() {
-            expect(testEmitter.model.navigableItems.length).toEqual(2);
+        it('model should have 3 items', function() {
+            expect(testEmitter.model.items.length).toEqual(3);
         });
     });
 });
@@ -91,12 +84,8 @@ describe('given a list of 3 hidden items', function() {
             testEmitter = NavigationEmitter.createLinear(testEl, 'li'); // eslint-disable-line
         });
 
-        it('model should have 3 matching items', function() {
-            expect(testEmitter.model.matchingItems.length).toEqual(3);
-        });
-
-        it('model should have 0 navigable items', function() {
-            expect(testEmitter.model.navigableItems.length).toEqual(0);
+        it('model should have 3 items', function() {
+            expect(testEmitter.model.items.length).toEqual(3);
         });
     });
 });
@@ -118,12 +107,8 @@ describe('given a list of 3 items with 1 aria-disabled', function() {
             testEmitter = NavigationEmitter.createLinear(testEl, 'li'); // eslint-disable-line
         });
 
-        it('model should have 3 matching items', function() {
-            expect(testEmitter.model.matchingItems.length).toEqual(3);
-        });
-
-        it('model should have 2 navigable items', function() {
-            expect(testEmitter.model.navigableItems.length).toEqual(2);
+        it('model should have 3 items', function() {
+            expect(testEmitter.model.items.length).toEqual(3);
         });
     });
 });
@@ -145,19 +130,15 @@ describe('given a list of 3 aria-disabled items', function() {
             testEmitter = NavigationEmitter.createLinear(testEl, 'li'); // eslint-disable-line
         });
 
-        it('model should have 3 matching items', function() {
-            expect(testEmitter.model.matchingItems.length).toEqual(3);
-        });
-
-        it('model should have 0 navigable items', function() {
-            expect(testEmitter.model.navigableItems.length).toEqual(0);
+        it('model should have 3 items', function() {
+            expect(testEmitter.model.items.length).toEqual(3);
         });
     });
 });
 
 /* END STATIC MODEL SIZE TESTS */
 
-/* BEGIN DYNAMIC MODEL SIZE TESTS */
+/* BEGIN MUTATION TESTS */
 
 describe('given a list of 3 visible items', function() {
     beforeAll(function() {
@@ -170,32 +151,25 @@ describe('given a list of 3 visible items', function() {
         `;
 
         testEl = document.querySelector('.widget');
+        onNavigationModelMutation = jasmine.createSpy('onNavigationModelMutation');
+        testEl.addEventListener('navigationModelMutation', onNavigationModelChange);
         testEmitter = NavigationEmitter.createLinear(testEl, 'li'); // eslint-disable-line
     });
 
-    describe('when first matching item is hidden', function() {
+    describe('when second item is hidden', function() {
         beforeAll(function() {
-           testEmitter.model.matchingItems[0].hidden = true;
+           testEmitter.model.items[1].hidden = true;
         });
 
-        it('model should have 2 navigable items', function() {
-            expect(testEmitter.model.navigableItems.length).toEqual(2);
-        });
-    });
-
-    describe('when first item is hidden and then unhidden', function() {
-        beforeAll(function() {
-           testEmitter.model.matchingItems[0].hidden = true;
-           testEmitter.model.matchingItems[0].hidden = false;
-        });
-
-        it('model should have 3 navigable items', function() {
-            expect(testEmitter.model.navigableItems.length).toEqual(3);
+        it('should trigger 1 navigationModelMutation event', function() {
+            setTimeout(function() { 
+                expect(onNavigationModelMutation).toHaveBeenCalledTimes(1);
+            }, timeoutInterval);
         });
     });
 });
 
-/* END DYNAMIC MODEL SIZE TESTS */
+/* END MUTATION TESTS */
 
 /* BEGIN ARROW KEY TESTS */
 

--- a/packages/makeup-navigation-emitter/test/index.js
+++ b/packages/makeup-navigation-emitter/test/index.js
@@ -711,12 +711,12 @@ describe('given 3 items', function() {
             testEmitter = NavigationEmitter.createLinear(testEl, 'li', {autoInit: null}); // eslint-disable-line
         });
 
-        it('should not trigger navigationModelInit event', function() {
-            expect(onNavigationModelInit).not.toHaveBeenCalled();
+        it('should trigger navigationModelInit event', function() {
+            expect(onNavigationModelInit).toHaveBeenCalledTimes(1);
         });
 
-        it('should have index value of undefined', function() {
-            expect(testEmitter.model.index).toBe(undefined);
+        it('should have index value of null', function() {
+            expect(testEmitter.model.index).toBe(null);
         });
     });
 
@@ -752,9 +752,9 @@ describe('given 3 items', function() {
         });
     });
 
-    describe('when autoInit is aria-selected', function() {
+    describe('when autoInit is ariaSelected', function() {
         beforeAll(function() {
-            testEmitter = NavigationEmitter.createLinear(testEl, 'li', {autoInit: 'aria-selected'}); // eslint-disable-line
+            testEmitter = NavigationEmitter.createLinear(testEl, 'li', {autoInit: 'ariaSelected'}); // eslint-disable-line
         });
 
         it('should trigger navigationModelInit event once', function() {

--- a/packages/makeup-navigation-emitter/test/index.js
+++ b/packages/makeup-navigation-emitter/test/index.js
@@ -37,13 +37,17 @@ describe('given a list of 3 visible items', function() {
             testEmitter = NavigationEmitter.createLinear(testEl, 'li'); // eslint-disable-line
         });
 
-        it('model should have 3 items', function() {
-            expect(testEmitter.model.filteredItems.length).toEqual(3);
+        it('model should have 3 matching items', function() {
+            expect(testEmitter.model.matchingItems.length).toEqual(3);
+        });
+
+        it('model should have 3 navigable items', function() {
+            expect(testEmitter.model.navigableItems.length).toEqual(3);
         });
     });
 });
 
-describe('given a list of 2 visible items, 1 hidden', function() {
+describe('given a list of 3 items with 1 hidden', function() {
     beforeAll(function() {
         document.body.innerHTML = `
             <ul class="widget">
@@ -60,8 +64,12 @@ describe('given a list of 2 visible items, 1 hidden', function() {
             testEmitter = NavigationEmitter.createLinear(testEl, 'li'); // eslint-disable-line
         });
 
-        it('model should have 2 items', function() {
-            expect(testEmitter.model.filteredItems.length).toEqual(2);
+        it('model should have 3 matching items', function() {
+            expect(testEmitter.model.matchingItems.length).toEqual(3);
+        });
+
+        it('model should have 2 navigable items', function() {
+            expect(testEmitter.model.navigableItems.length).toEqual(2);
         });
     });
 });
@@ -83,8 +91,66 @@ describe('given a list of 3 hidden items', function() {
             testEmitter = NavigationEmitter.createLinear(testEl, 'li'); // eslint-disable-line
         });
 
-        it('model should have 0 items', function() {
-            expect(testEmitter.model.filteredItems.length).toEqual(0);
+        it('model should have 3 matching items', function() {
+            expect(testEmitter.model.matchingItems.length).toEqual(3);
+        });
+
+        it('model should have 0 navigable items', function() {
+            expect(testEmitter.model.navigableItems.length).toEqual(0);
+        });
+    });
+});
+
+describe('given a list of 3 items with 1 aria-disabled', function() {
+    beforeAll(function() {
+        document.body.innerHTML = `
+            <ul class="widget">
+                <li>Item 1</li>
+                <li aria-disabled="true">Item 2</li>
+                <li>Item 3</li>
+            </ul>
+        `;
+    });
+
+    describe('when instantiated', function() {
+        beforeAll(function() {
+            testEl = document.querySelector('.widget');
+            testEmitter = NavigationEmitter.createLinear(testEl, 'li'); // eslint-disable-line
+        });
+
+        it('model should have 3 matching items', function() {
+            expect(testEmitter.model.matchingItems.length).toEqual(3);
+        });
+
+        it('model should have 2 navigable items', function() {
+            expect(testEmitter.model.navigableItems.length).toEqual(2);
+        });
+    });
+});
+
+describe('given a list of 3 aria-disabled items', function() {
+    beforeAll(function() {
+        document.body.innerHTML = `
+            <ul class="widget">
+                <li aria-disabled="true">Item 1</li>
+                <li aria-disabled="true">Item 2</li>
+                <li aria-disabled="true">Item 3</li>
+            </ul>
+        `;
+    });
+
+    describe('when instantiated', function() {
+        beforeAll(function() {
+            testEl = document.querySelector('.widget');
+            testEmitter = NavigationEmitter.createLinear(testEl, 'li'); // eslint-disable-line
+        });
+
+        it('model should have 3 matching items', function() {
+            expect(testEmitter.model.matchingItems.length).toEqual(3);
+        });
+
+        it('model should have 0 navigable items', function() {
+            expect(testEmitter.model.navigableItems.length).toEqual(0);
         });
     });
 });
@@ -107,24 +173,24 @@ describe('given a list of 3 visible items', function() {
         testEmitter = NavigationEmitter.createLinear(testEl, 'li'); // eslint-disable-line
     });
 
-    describe('when first item is hidden', function() {
+    describe('when first matching item is hidden', function() {
         beforeAll(function() {
-           testEmitter.model.items[0].hidden = true;
+           testEmitter.model.matchingItems[0].hidden = true;
         });
 
-        it('model should have 2 items', function() {
-            expect(testEmitter.model.filteredItems.length).toEqual(2);
+        it('model should have 2 navigable items', function() {
+            expect(testEmitter.model.navigableItems.length).toEqual(2);
         });
     });
 
     describe('when first item is hidden and then unhidden', function() {
         beforeAll(function() {
-           testEmitter.model.items[0].hidden = true;
-           testEmitter.model.items[0].hidden = false;
+           testEmitter.model.matchingItems[0].hidden = true;
+           testEmitter.model.matchingItems[0].hidden = false;
         });
 
-        it('model should have 3 items', function() {
-            expect(testEmitter.model.filteredItems.length).toEqual(3);
+        it('model should have 3 navigable items', function() {
+            expect(testEmitter.model.navigableItems.length).toEqual(3);
         });
     });
 });
@@ -627,7 +693,7 @@ describe('given 3 items', function() {
         document.body.innerHTML = `
             <ul class="widget">
                 <li>Item 1</li>
-                <li>Item 2</li>
+                <li aria-selected="true">Item 2</li>
                 <li>Item 3</li>
             </ul>
         `;
@@ -673,6 +739,22 @@ describe('given 3 items', function() {
     describe('when autoInit is 1', function() {
         beforeAll(function() {
             testEmitter = NavigationEmitter.createLinear(testEl, 'li', {autoInit: 1}); // eslint-disable-line
+        });
+
+        it('should trigger navigationModelInit event once', function() {
+            setTimeout(function() { 
+                expect(onNavigationModelInit).toHaveBeenCalledTimes(1);
+            }, timeoutInterval);
+        });
+
+        it('should have index value of 1', function() {
+            expect(testEmitter.model.index).toBe(1);
+        });
+    });
+
+    describe('when autoInit is aria-selected', function() {
+        beforeAll(function() {
+            testEmitter = NavigationEmitter.createLinear(testEl, 'li', {autoInit: 'aria-selected'}); // eslint-disable-line
         });
 
         it('should trigger navigationModelInit event once', function() {

--- a/packages/makeup-roving-tabindex/README.md
+++ b/packages/makeup-roving-tabindex/README.md
@@ -50,7 +50,7 @@ Markup after:
 ## Options
 
 * `autoReset`: the index position that should receive the roving tabindex when model is reset (default: null)
-* `index`: the initial index position of the roving tabindex (default: 0)
+* `autoInit`: the initial index position of the roving tabindex (default: 'first')
 * `wrap` : specify whether arrow keys should wrap/loop (default: false)
 * `axis` : specify 'x' for left/right arrow keys, 'y' for up/down arrow keys, or 'both' (default: 'both')
 

--- a/packages/makeup-roving-tabindex/README.md
+++ b/packages/makeup-roving-tabindex/README.md
@@ -49,8 +49,20 @@ Markup after:
 
 ## Options
 
-* `autoReset`: the index position that should receive the roving tabindex when model is reset (default: null)
-* `autoInit`: the initial index position of the roving tabindex (default: 'first')
+* `autoInit`: declares the initial roving tabindex item (default: "interactive"). Possible values are:
+    * "none": no index position is set (useful in programmatic active-descendant)
+    * "interactive": first non aria-disabled or hidden element (default)
+    * "ariaChecked": first element with aria-checked=true (useful in ARIA menu)
+    * "ariaSelected": first element with aria-selected=true (useful in ARIA tabs)
+    * "ariaSelectedOrInteractive": first element with aria-selected=true, falling back to "interactive" if not found (useful in ARIA listbox)
+    * *number*: specific index position of items (throws error if non-interactive)
+* `autoReset`: declares the roving tabindex item after a reset and/or when keyboard focus exits the widget (default: "current"). Possible values are:
+    * "none": no index position is set (useful in programmatic active-descendant)
+    * "current": index remains current (radio button like behaviour)
+    * "interactive": index moves to first non aria-disabled or hidden element
+    * "ariaChecked": index moves to first element with aria-checked=true
+    * "ariaSelected": index moves to first element with aria-selected=true
+    * *number*: specific index position of items (throws error if non-interactive)
 * `wrap` : specify whether arrow keys should wrap/loop (default: false)
 * `axis` : specify 'x' for left/right arrow keys, 'y' for up/down arrow keys, or 'both' (default: 'both')
 
@@ -59,6 +71,7 @@ Markup after:
 * `navigableItems`: returns navigable subset of matchingItems (e.g. non-hidden items)
 * `index`: the index position of the roving tabindex (i.e. the element with tabindex="0"). A no-op on aria-disabled or hidden items.
 * `matchingItems`: returns all items that match item selector
+* `nonEmittingElementSelector`: CSS selector of nested elements that will *not* operate the navigation emitter. This is useful in a combobox + button scenario, where the nested button should not trigger navigationModelChange events (default: null)
 
 ## Methods
 
@@ -67,7 +80,16 @@ Markup after:
 
 ## Custom Events        
 
+* `rovingTabindexInit`
+    * detail
+        * items
+        * fromIndex
+        * toIndex
 * `rovingTabindexChange`
+    * detail
+        * fromIndex
+        * toIndex
+* `rovingTabindexReset`
     * detail
         * fromIndex
         * toIndex

--- a/packages/makeup-roving-tabindex/README.md
+++ b/packages/makeup-roving-tabindex/README.md
@@ -71,7 +71,7 @@ Markup after:
 * `navigableItems`: returns navigable subset of matchingItems (e.g. non-hidden items)
 * `index`: the index position of the roving tabindex (i.e. the element with tabindex="0"). A no-op on aria-disabled or hidden items.
 * `matchingItems`: returns all items that match item selector
-* `nonEmittingElementSelector`: CSS selector of nested elements that will *not* operate the navigation emitter. This is useful in a combobox + button scenario, where the nested button should not trigger navigationModelChange events (default: null)
+* `ignoreByDelegateSelector`: CSS selector of descendant elements that will be ignored by the navigation emitters key event delegation (i.e. these elements will *not* operate the roving tabindex) (default: null)
 
 ## Methods
 

--- a/packages/makeup-roving-tabindex/README.md
+++ b/packages/makeup-roving-tabindex/README.md
@@ -56,9 +56,9 @@ Markup after:
 
 ## Properties
 
-* `filteredItems`: returns filtered items (e.g. non-hidden items)
-* `index`: the index position of the roving tabindex (i.e. the element with tabindex="0")
-* `items`: returns all items that match item selector
+* `navigableItems`: returns navigable subset of matchingItems (e.g. non-hidden items)
+* `index`: the index position of the roving tabindex (i.e. the element with tabindex="0"). A no-op on aria-disabled or hidden items.
+* `matchingItems`: returns all items that match item selector
 
 ## Methods
 

--- a/packages/makeup-roving-tabindex/README.md
+++ b/packages/makeup-roving-tabindex/README.md
@@ -40,9 +40,9 @@ Markup after:
 ```html
 <div class="widget">
     <ul>
-        <li data-makeup-index="0" tabindex="0">Item 1</li>
-        <li data-makeup-index="1" tabindex="-1">Item 2</li>
-        <li data-makeup-index="2" tabindex="-1">Item 3</li>
+        <li tabindex="0">Item 1</li>
+        <li tabindex="-1">Item 2</li>
+        <li tabindex="-1">Item 3</li>
     </ul>
 </div>
 ```

--- a/packages/makeup-roving-tabindex/src/index.js
+++ b/packages/makeup-roving-tabindex/src/index.js
@@ -86,8 +86,9 @@ class LinearRovingTabindex extends RovingTabindex {
 
         this._itemSelector = itemSelector;
 
+        // todo: options.index is deprecated. Remove support in future release.
         this._navigationEmitter = NavigationEmitter.createLinear(el, itemSelector, {
-            autoInit: this._options.autoInit,
+            autoInit: (this._options.index !== undefined) ? this._options.index : this._options.autoInit,
             autoReset: this._options.autoReset,
             wrap: this._options.wrap,
             axis: this._options.axis

--- a/packages/makeup-roving-tabindex/src/index.js
+++ b/packages/makeup-roving-tabindex/src/index.js
@@ -109,6 +109,10 @@ class LinearRovingTabindex extends RovingTabindex {
         this._navigationEmitter.model.options.wrap = newWrap;
     }
 
+    get currentItem() {
+        return this._navigationEmitter.model.currentItem;
+    }
+
     get navigableItems() {
         return this._navigationEmitter.model.navigableItems;
     }

--- a/packages/makeup-roving-tabindex/src/index.js
+++ b/packages/makeup-roving-tabindex/src/index.js
@@ -12,8 +12,9 @@ const defaultOptions = {
 function onModelMutation(e) {
     const { toIndex } = e.detail;
 
-    this.navigableItems.filter((el, i) => i !== toIndex).forEach((el) => el.setAttribute('tabindex', '-1'));
-    if (toIndex !== null) this.matchingItems[toIndex].setAttribute('tabindex', '0');
+    this.items.forEach((el) => el.setAttribute('tabindex', '-1'));
+    const el = this.items[toIndex];
+    if (el) el.setAttribute('tabindex', '0');
 
     this._el.dispatchEvent(new CustomEvent('rovingTabindexMutation', { detail: e.detail }));
 }
@@ -32,7 +33,7 @@ function onModelInit(e) {
 }
 
 function onModelReset(e) {
-    const items = this.matchingItems;
+    const items = this.items;
 
     items.filter((el, i) => i !== e.detail.toIndex).forEach((el) => el.setAttribute('tabindex', '-1'));
     items[e.detail.toIndex].setAttribute('tabindex', '0');
@@ -41,7 +42,7 @@ function onModelReset(e) {
 }
 
 function onModelChange(e) {
-    const items = this.matchingItems;
+    const items = this.items;
 
     const fromItem = items[e.detail.fromIndex];
     const toItem = items[e.detail.toIndex];
@@ -113,20 +114,8 @@ class LinearRovingTabindex extends RovingTabindex {
         return this._navigationEmitter.model.currentItem;
     }
 
-    get navigableItems() {
-        return this._navigationEmitter.model.navigableItems;
-    }
-
-    get matchingItems() {
-        return this._navigationEmitter.model.matchingItems;
-    }
-
-    next() {
-        this._navigationEmitter.model.gotoNextNavigableIndex();
-    }
-
-    previous() {
-        this._navigationEmitter.model.gotoPreviousNavigableIndex();
+    get items() {
+        return this._navigationEmitter.model.items;
     }
 
     reset() {

--- a/packages/makeup-roving-tabindex/src/index.js
+++ b/packages/makeup-roving-tabindex/src/index.js
@@ -2,42 +2,41 @@
 
 import * as NavigationEmitter from 'makeup-navigation-emitter';
 
+// todo: rename autoReset to make it clearer it is for kb focus behaviour
 const defaultOptions = {
     autoReset: null,
+    // todo: what if if index element is disabled or hidden?
+    // Leverage navigationEmitter.firstNavigableIndex?
     index: 0,
     wrap: false,
     axis: 'both'
 };
 
-const nodeListToArray = (nodeList) => Array.prototype.slice.call(nodeList);
-
 function onModelMutation() {
     const modelIndex = this._navigationEmitter.model.index;
 
-    this.filteredItems.forEach((el, index) => el.setAttribute('tabindex', index !== modelIndex ? '-1' : '0'));
+    this.navigableItems.forEach((el, index) => el.setAttribute('tabindex', index !== modelIndex ? '-1' : '0'));
 }
 
 function onModelInit(e) {
-    const items = e.detail.items;
+    const { items, toIndex } = e.detail;
 
-    nodeListToArray(items).filter((el, i) => i !== e.detail.toIndex).forEach(el => el.setAttribute('tabindex', '-1'));
+    items.filter((el, i) => i !== toIndex).forEach((el) => el.setAttribute('tabindex', '-1'));
 
-    if (items[e.detail.toIndex]) {
-        items[e.detail.toIndex].setAttribute('tabindex', '0');
+    if (items[toIndex]) {
+        items[toIndex].setAttribute('tabindex', '0');
     }
 }
 
 function onModelReset(e) {
-    this._index = e.detail.toIndex; // seems unused internally. scheduled for deletion.
+    const items = this.matchingItems;
 
-    const items = this.filteredItems;
-
-    nodeListToArray(items).filter((el, i) => i !== e.detail.toIndex).forEach(el => el.setAttribute('tabindex', '-1'));
+    items.filter((el, i) => i !== e.detail.toIndex).forEach((el) => el.setAttribute('tabindex', '-1'));
     items[e.detail.toIndex].setAttribute('tabindex', '0');
 }
 
 function onModelChange(e) {
-    const items = this.filteredItems;
+    const items = this.matchingItems;
 
     const fromItem = items[e.detail.fromIndex];
     const toItem = items[e.detail.toIndex];
@@ -97,10 +96,12 @@ class LinearRovingTabindex extends RovingTabindex {
         });
     }
 
+    // todo: rename or remove
     get index() {
         return this._navigationEmitter.model.index;
     }
 
+    // todo: rename or remove
     set index(newIndex) {
         this._navigationEmitter.model.index = newIndex;
     }
@@ -109,19 +110,15 @@ class LinearRovingTabindex extends RovingTabindex {
         this._navigationEmitter.model.options.wrap = newWrap;
     }
 
-    get filteredItems() {
-        return this._navigationEmitter.model.filteredItems;
+    get navigableItems() {
+        return this._navigationEmitter.model.navigableItems;
     }
 
-    get items() {
-        return this._navigationEmitter.model.items;
+    get matchingItems() {
+        return this._navigationEmitter.model.matchingItems;
     }
 
-    // backwards compat
-    get _items() {
-        return this.items;
-    }
-
+    // todo: rename
     reset() {
         this._navigationEmitter.model.reset();
     }

--- a/packages/makeup-roving-tabindex/src/index.js
+++ b/packages/makeup-roving-tabindex/src/index.js
@@ -5,9 +5,7 @@ import * as NavigationEmitter from 'makeup-navigation-emitter';
 // todo: rename autoReset to make it clearer it is for kb focus behaviour
 const defaultOptions = {
     autoReset: null,
-    // todo: what if if index element is disabled or hidden?
-    // Leverage navigationEmitter.firstNavigableIndex?
-    index: 0,
+    autoInit: 'first',
     wrap: false,
     axis: 'both'
 };
@@ -89,7 +87,7 @@ class LinearRovingTabindex extends RovingTabindex {
         this._itemSelector = itemSelector;
 
         this._navigationEmitter = NavigationEmitter.createLinear(el, itemSelector, {
-            autoInit: this._options.index,
+            autoInit: this._options.autoInit,
             autoReset: this._options.autoReset,
             wrap: this._options.wrap,
             axis: this._options.axis

--- a/packages/makeup-roving-tabindex/test/index.js
+++ b/packages/makeup-roving-tabindex/test/index.js
@@ -40,7 +40,7 @@ describe('given a list of 3 visible items', function() {
         });
 
         it('model should have 3 items', function() {
-            expect(testRovingIndex.filteredItems.length).toEqual(3);
+            expect(testRovingIndex.navigableItems.length).toEqual(3);
         });
     });
 });
@@ -63,7 +63,7 @@ describe('given a list of 2 visible items, 1 hidden', function() {
         });
 
         it('model should have 2 items', function() {
-            expect(testRovingIndex.filteredItems.length).toEqual(2);
+            expect(testRovingIndex.navigableItems.length).toEqual(2);
         });
     });
 });
@@ -86,7 +86,7 @@ describe('given a list of 3 hidden items', function() {
         });
 
         it('model should have 0 items', function() {
-            expect(testRovingIndex.filteredItems.length).toEqual(0);
+            expect(testRovingIndex.navigableItems.length).toEqual(0);
         });
     });
 });
@@ -111,22 +111,22 @@ describe('given a list of 3 visible items', function() {
 
     describe('when first item is hidden', function() {
         beforeAll(function() {
-            testRovingIndex.items[0].hidden = true;
+            testRovingIndex.matchingItems[0].hidden = true;
         });
 
         it('model should have 2 items', function() {
-            expect(testRovingIndex.filteredItems.length).toEqual(2);
+            expect(testRovingIndex.navigableItems.length).toEqual(2);
         });
     });
 
     describe('when first item is hidden and then unhidden', function() {
         beforeAll(function() {
-            testRovingIndex.items[0].hidden = true;
-            testRovingIndex.items[0].hidden = false;
+            testRovingIndex.matchingItems[0].hidden = true;
+            testRovingIndex.matchingItems[0].hidden = false;
         });
 
         it('model should have 3 items', function() {
-            expect(testRovingIndex.filteredItems.length).toEqual(3);
+            expect(testRovingIndex.navigableItems.length).toEqual(3);
         });
     });
 });

--- a/packages/makeup-roving-tabindex/test/index.js
+++ b/packages/makeup-roving-tabindex/test/index.js
@@ -35,12 +35,8 @@ describe('given a list of 3 visible items', function() {
             testRovingIndex = RovingTabindex.createLinear(testEl, 'li'); // eslint-disable-line
         });
 
-        it('module should not be undefined', function() {
-            expect(RovingTabindex).not.toEqual(undefined);
-        });
-
         it('model should have 3 items', function() {
-            expect(testRovingIndex.navigableItems.length).toEqual(3);
+            expect(testRovingIndex.items.length).toEqual(3);
         });
     });
 });
@@ -62,8 +58,8 @@ describe('given a list of 2 visible items, 1 hidden', function() {
             testRovingIndex = RovingTabindex.createLinear(testEl, 'li'); // eslint-disable-line
         });
 
-        it('model should have 2 items', function() {
-            expect(testRovingIndex.navigableItems.length).toEqual(2);
+        it('model should have 3 items', function() {
+            expect(testRovingIndex.items.length).toEqual(3);
         });
     });
 });
@@ -85,53 +81,13 @@ describe('given a list of 3 hidden items', function() {
             testRovingIndex = RovingTabindex.createLinear(testEl, 'li'); // eslint-disable-line
         });
 
-        it('model should have 0 items', function() {
-            expect(testRovingIndex.navigableItems.length).toEqual(0);
+        it('model should have 3 items', function() {
+            expect(testRovingIndex.items.length).toEqual(3);
         });
     });
 });
 
 /* END STATIC MODEL SIZE TESTS */
-
-/* BEGIN DYNAMIC MODEL SIZE TESTS */
-
-describe('given a list of 3 visible items', function() {
-    beforeAll(function() {
-        document.body.innerHTML = `
-            <ul class="widget">
-                <li>Item 1</li>
-                <li>Item 2</li>
-                <li>Item 3</li>
-            </ul>
-        `;
-
-        testEl = document.querySelector('.widget');
-        testRovingIndex = RovingTabindex.createLinear(testEl, 'li'); // eslint-disable-line
-    });
-
-    describe('when first item is hidden', function() {
-        beforeAll(function() {
-            testRovingIndex.matchingItems[0].hidden = true;
-        });
-
-        it('model should have 2 items', function() {
-            expect(testRovingIndex.navigableItems.length).toEqual(2);
-        });
-    });
-
-    describe('when first item is hidden and then unhidden', function() {
-        beforeAll(function() {
-            testRovingIndex.matchingItems[0].hidden = true;
-            testRovingIndex.matchingItems[0].hidden = false;
-        });
-
-        it('model should have 3 items', function() {
-            expect(testRovingIndex.navigableItems.length).toEqual(3);
-        });
-    });
-});
-
-/* END DYNAMIC MODEL SIZE TESTS */
 
 /* BEGIN ARROW KEY TESTS */
 


### PR DESCRIPTION
Closes #87.

<strike>Given that I think we always want to remove hidden elements from any keyboard navigation logic, or selection logic, I have simplified how hidden elements are filtered.

The item filter is replaced, and we just hijack the CSS itemSelector now instead. The `.filteredItems()` getter is now removed, which cleans up the code a lot. Rovingtabindex and active-descendant now just access the regular `.items()` getter.

This PR also starts to create a clearer boundary between the models for keyboard navigable items and their current index, and programmatically selectable items (i.e. aria-selected or aria-checked) and their current index . "Items" in navigation-emitter is going to mean keyboard navigable items only, whereas "items" in other places will mean ALL items except hidden items.

There is some more renaming of things and other cleanup that needs to be done, but wanted to keep this initial PR clean. I left in some CSS for aria-disabled on demo pages in readiness for us starting to add that logic.

Let's first check that nothing broke before moving on to plugging in support for disabled elements.</strike>

Most of this is not correct anymore. I will update when converting this from draft to final PR.