### PR TITLE
test: refactor navigation-emitter test structure

### DIFF
--- a/packages/makeup-navigation-emitter/test/index.js
+++ b/packages/makeup-navigation-emitter/test/index.js
@@ -30,7 +30,7 @@ describe('given a list of 3 visible items', function() {
         });
 
         it('model should have 3 items', function() {
-            expect(testEmitter.model.items.length).toEqual(3);
+            expect(testEmitter.model.filteredItems.length).toEqual(3);
         });
     });
 });
@@ -53,7 +53,7 @@ describe('given a list of 2 visible items, 1 hidden', function() {
         });
 
         it('model should have 2 items', function() {
-            expect(testEmitter.model.items.length).toEqual(2);
+            expect(testEmitter.model.filteredItems.length).toEqual(2);
         });
     });
 });
@@ -76,7 +76,7 @@ describe('given a list of 3 hidden items', function() {
         });
 
         it('model should have 0 items', function() {
-            expect(testEmitter.model.items.length).toEqual(0);
+            expect(testEmitter.model.filteredItems.length).toEqual(0);
         });
     });
 });

--- a/packages/makeup-navigation-emitter/test/index.js
+++ b/packages/makeup-navigation-emitter/test/index.js
@@ -10,7 +10,7 @@ function triggerArrowKeyPress(el, dir, num) {
     }
 }
 
-/* BEGIN MODEL SIZE TESTS */
+/* BEGIN STATIC MODEL SIZE TESTS */
 
 describe('given a list of 3 visible items', function() {
     beforeAll(function() {
@@ -81,7 +81,47 @@ describe('given a list of 3 hidden items', function() {
     });
 });
 
-/* END MODEL SIZE TESTS */
+/* END STATIC MODEL SIZE TESTS */
+
+/* BEGIN DYNAMIC MODEL SIZE TESTS */
+
+describe('given a list of 3 visible items', function() {
+    beforeAll(function() {
+        document.body.innerHTML = `
+            <ul class="widget">
+                <li>Item 1</li>
+                <li>Item 2</li>
+                <li>Item 3</li>
+            </ul>
+        `;
+
+        testEl = document.querySelector('.widget');
+        testEmitter = NavigationEmitter.createLinear(testEl, 'li'); // eslint-disable-line
+    });
+
+    describe('when first item is hidden', function() {
+        beforeAll(function() {
+           testEmitter.model.items[0].hidden = true;
+        });
+
+        it('model should have 2 items', function() {
+            expect(testEmitter.model.filteredItems.length).toEqual(2);
+        });
+    });
+
+    describe('when first item is hidden and then unhidden', function() {
+        beforeAll(function() {
+           testEmitter.model.items[0].hidden = true;
+           testEmitter.model.items[0].hidden = false;
+        });
+
+        it('model should have 3 items', function() {
+            expect(testEmitter.model.filteredItems.length).toEqual(3);
+        });
+    });
+});
+
+/* END DYNAMIC MODEL SIZE TESTS */
 
 /* BEGIN ARROW KEY TESTS */
 

--- a/packages/makeup-navigation-emitter/test/index.js
+++ b/packages/makeup-navigation-emitter/test/index.js
@@ -1,181 +1,331 @@
 import * as NavigationEmitter from '../src/index.js';
 
-describe('makeup-navigation-emitter', function() {
-    var dom = '<ul class="widget">'
-                + '<li>Button 1</li>'
-                + '<li>Button 2</li>'
-                + '<li>Button 3</li>'
-            + '</ul>';
+var testEl,
+    testEmitter,
+    onNavigationModelChange;
 
-    describe('when module is imported', function() {
-        it('module should not be undefined', function() {
-            expect(NavigationEmitter).not.toEqual(undefined);
-        });
+function triggerArrowKeyPress(el, dir, num) {
+    for(let i = 0; i < num; i++) {
+        el.dispatchEvent(new CustomEvent(`arrow${dir}KeyDown`, {detail:{target:{tagName:''}}}));
+    }
+}
+
+/* BEGIN MODEL SIZE TESTS */
+
+describe('given a list of 3 visible items', function() {
+    beforeAll(function() {
+        document.body.innerHTML = `
+            <ul class="widget">
+                <li>Item 1</li>
+                <li>Item 2</li>
+                <li>Item 3</li>
+            </ul>
+        `;
     });
 
-    describe('when emitter is created with default options in default state', function() {
-        var testEl;
-        var testEmitter;
-        var onNavigationModelChange;
-
-        beforeEach(function() {
-            document.body.innerHTML = dom;
-
+    describe('when instantiated', function() {
+        beforeAll(function() {
             testEl = document.querySelector('.widget');
             testEmitter = NavigationEmitter.createLinear(testEl, 'li'); // eslint-disable-line
-
-            onNavigationModelChange = jasmine.createSpy('onNavigationModelChange');
-            testEl.addEventListener('navigationModelChange', onNavigationModelChange);
         });
 
-        it('should trigger 0 navigationModelChange event on arrow left', function() {
-            // execute
-            testEl.dispatchEvent(new CustomEvent('arrowLeftKeyDown', {detail:{target:{tagName:''}}}));
-            // assert
-            expect(onNavigationModelChange).toHaveBeenCalledTimes(0);
+        it('model should have 3 items', function() {
+            expect(testEmitter.model.items.length).toEqual(3);
+        });
+    });
+});
+
+describe('given a list of 2 visible items, 1 hidden', function() {
+    beforeAll(function() {
+        document.body.innerHTML = `
+            <ul class="widget">
+                <li>Item 1</li>
+                <li hidden>Item 2</li>
+                <li>Item 3</li>
+            </ul>
+        `;
+    });
+
+    describe('when instantiated', function() {
+        beforeAll(function() {
+            testEl = document.querySelector('.widget');
+            testEmitter = NavigationEmitter.createLinear(testEl, 'li'); // eslint-disable-line
         });
 
-        it('should trigger 0 navigationModelChange event on arrow up', function() {
-            // execute
-            testEl.dispatchEvent(new CustomEvent('arrowUpKeyDown', {detail:{target:{tagName:''}}}));
-            // assert
-            expect(onNavigationModelChange).toHaveBeenCalledTimes(0);
+        it('model should have 2 items', function() {
+            expect(testEmitter.model.items.length).toEqual(2);
+        });
+    });
+});
+
+describe('given a list of 3 hidden items', function() {
+    beforeAll(function() {
+        document.body.innerHTML = `
+            <ul class="widget">
+                <li hidden>Item 1</li>
+                <li hidden>Item 2</li>
+                <li hidden>Item 3</li>
+            </ul>
+        `;
+    });
+
+    describe('when instantiated', function() {
+        beforeAll(function() {
+            testEl = document.querySelector('.widget');
+            testEmitter = NavigationEmitter.createLinear(testEl, 'li'); // eslint-disable-line
         });
 
-        it('should trigger 1 navigationModelChange event on arrow right', function() {
-            // execute
-            testEl.dispatchEvent(new CustomEvent('arrowRightKeyDown', {detail:{target:{tagName:''}}}));
-            // assert
-            expect(onNavigationModelChange).toHaveBeenCalledTimes(1);
-            // remove the listeners
-            testEmitter.destroy();
-            // execute
-            testEl.dispatchEvent(new CustomEvent('arrowRightKeyDown', {detail:{target:{tagName:''}}}));
-            // assert
-            expect(onNavigationModelChange).toHaveBeenCalledTimes(1);
+        it('model should have 0 items', function() {
+            expect(testEmitter.model.items.length).toEqual(0);
+        });
+    });
+});
+
+/* END MODEL SIZE TESTS */
+
+/* BEGIN ARROW KEY TESTS */
+
+describe('given 3 items with default options', function() {
+    function setup() {
+        document.body.innerHTML = `
+            <ul class="widget">
+                <li>Item 1</li>
+                <li>Item 2</li>
+                <li>Item 3</li>
+            </ul>
+        `;
+
+        testEl = document.querySelector('.widget');
+        testEmitter = NavigationEmitter.createLinear(testEl, 'li'); // eslint-disable-line
+
+        onNavigationModelChange = jasmine.createSpy('onNavigationModelChange');
+        testEl.addEventListener('navigationModelChange', onNavigationModelChange);
+    }
+
+    beforeAll(setup);
+    afterEach(setup);
+
+    describe('when arrow left is pressed once', function() {
+        beforeAll(function() {
+            triggerArrowKeyPress(testEl, 'Left', 1);
         });
 
-        it('should trigger 1 navigationModelChange event on arrow down', function() {
-            // execute
-            testEl.dispatchEvent(new CustomEvent('arrowDownKeyDown', {detail:{target:{tagName:''}}}));
-            // assert
-            expect(onNavigationModelChange).toHaveBeenCalledTimes(1);
-            // remove the listeners
-            testEmitter.destroy();
-            // execute
-            testEl.dispatchEvent(new CustomEvent('arrowDownKeyDown', {detail:{target:{tagName:''}}}));
-            // assert
-            expect(onNavigationModelChange).toHaveBeenCalledTimes(1);
-        });
-
-        it('should trigger 0 navigationModelChange event when index set to current index', function() {
-            // execute
-            testEmitter.model.index = 0;
-            // assert
-            expect(onNavigationModelChange).toHaveBeenCalledTimes(0);
-        });
-
-        it('should trigger 1 navigationModelChange event when index set within bounds', function() {
-            // execute
-            testEmitter.model.index = 1;
-            // assert
-            expect(onNavigationModelChange).toHaveBeenCalledTimes(1);
-        });
-
-        it('should trigger 0 navigationModelChange event when index set out of bounds', function() {
-            // execute
-            testEmitter.model.index = 100;
-            // assert
+        it('should trigger 0 navigationModelChange events', function() {
             expect(onNavigationModelChange).toHaveBeenCalledTimes(0);
         });
     });
 
-    describe('when emitter is created with default options in default state with autoWrap', function() {
-        var testEl;
-        var onNavigationModelChange;
-        var testEmitter;
-
-        beforeEach(function() {
-            document.body.innerHTML = dom;
-
-            testEl = document.querySelector('.widget');
-            testEmitter = NavigationEmitter.createLinear(testEl, 'li', { wrap: true }); // eslint-disable-line
-
-            onNavigationModelChange = jasmine.createSpy('onNavigationModelChange');
-            testEl.addEventListener('navigationModelChange', onNavigationModelChange);
+    describe('when arrow up is pressed once', function() {
+        beforeAll(function() {
+            triggerArrowKeyPress(testEl, 'Up', 1);
         });
 
-        it('should trigger 1 navigationModelChange event on arrow left', function() {
-            // execute
-            testEl.dispatchEvent(new CustomEvent('arrowLeftKeyDown', {detail:{target:{tagName:''}}}));
-            // assert
-            expect(onNavigationModelChange).toHaveBeenCalledTimes(1);
-            // remove the listeners
-            testEmitter.destroy();
-            // execute
-            testEl.dispatchEvent(new CustomEvent('arrowLeftKeyDown', {detail:{target:{tagName:''}}}));
-            // assert
-            expect(onNavigationModelChange).toHaveBeenCalledTimes(1);
-        });
-
-        it('should trigger 1 navigationModelChange event on arrow up', function() {
-            // execute
-            testEl.dispatchEvent(new CustomEvent('arrowUpKeyDown', {detail:{target:{tagName:''}}}));
-            // assert
-            expect(onNavigationModelChange).toHaveBeenCalledTimes(1);
-            // remove the listeners
-            testEmitter.destroy();
-            // execute
-            testEl.dispatchEvent(new CustomEvent('arrowUpKeyDown', {detail:{target:{tagName:''}}}));
-            // assert
-            expect(onNavigationModelChange).toHaveBeenCalledTimes(1);
-        });
-
-        it('should trigger 1 navigationModelChange event on arrow right', function() {
-            // execute
-            testEl.dispatchEvent(new CustomEvent('arrowRightKeyDown', {detail:{target:{tagName:''}}}));
-            // assert
-            expect(onNavigationModelChange).toHaveBeenCalledTimes(1);
-            // remove the listeners
-            testEmitter.destroy();
-            // execute
-            testEl.dispatchEvent(new CustomEvent('arrowRightKeyDown', {detail:{target:{tagName:''}}}));
-            // assert
-            expect(onNavigationModelChange).toHaveBeenCalledTimes(1);
-        });
-
-        it('should trigger 1 navigationModelChange event on arrow down', function() {
-            // execute
-            testEl.dispatchEvent(new CustomEvent('arrowDownKeyDown', {detail:{target:{tagName:''}}}));
-            // assert
-            expect(onNavigationModelChange).toHaveBeenCalledTimes(1);
-            // remove the listeners
-            testEmitter.destroy();
-            // execute
-            testEl.dispatchEvent(new CustomEvent('arrowDownKeyDown', {detail:{target:{tagName:''}}}));
-            // assert
-            expect(onNavigationModelChange).toHaveBeenCalledTimes(1);
-        });
-
-        it('should trigger 0 navigationModelChange event when index set to current index', function() {
-            // execute
-            testEmitter.model.index = 0;
-            // assert
+        it('should trigger 0 navigationModelChange events', function() {
             expect(onNavigationModelChange).toHaveBeenCalledTimes(0);
         });
+    });
 
-        it('should trigger 1 navigationModelChange event when index set within bounds', function() {
-            // execute
-            testEmitter.model.index = 1;
-            // assert
-            expect(onNavigationModelChange).toHaveBeenCalledTimes(1);
+    describe('when arrow right is pressed once', function() {
+        beforeAll(function() {
+            triggerArrowKeyPress(testEl, 'Right', 1);
         });
 
-        it('should trigger 0 navigationModelChange event when index set out of bounds', function() {
-            // execute
-            testEmitter.model.index = 100;
-            // assert
+        it('should trigger 1 navigationModelChange events', function() {
+            expect(onNavigationModelChange).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('when arrow right is pressed twice', function() {
+        beforeAll(function() {
+            triggerArrowKeyPress(testEl, 'Right', 2);
+        });
+
+        it('should trigger 2 navigationModelChange events', function() {
+            expect(onNavigationModelChange).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('when arrow right is pressed three times', function() {
+        beforeAll(function() {
+            triggerArrowKeyPress(testEl, 'Right', 3);
+        });
+
+        it('should trigger 2 navigationModelChange events', function() {
+            expect(onNavigationModelChange).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('when arrow right is pressed once after emitter is destroyed', function() {
+        beforeAll(function() {
+            testEmitter.destroy();
+            triggerArrowKeyPress(testEl, 'Right', 1);
+        });
+
+        it('should trigger 0 navigationModelChange events', function() {
+            expect(onNavigationModelChange).toHaveBeenCalledTimes(0);
+        });
+    });
+
+    describe('when arrow down is pressed once', function() {
+        beforeAll(function() {
+            triggerArrowKeyPress(testEl, 'Down', 1);
+        });
+
+        it('should trigger 1 navigationModelChange events', function() {
+            expect(onNavigationModelChange).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('when arrow down is pressed once after emitter is destroyed', function() {
+        beforeAll(function() {
+            testEmitter.destroy();
+            triggerArrowKeyPress(testEl, 'Down', 1);
+        });
+
+        it('should trigger 0 navigationModelChange events', function() {
             expect(onNavigationModelChange).toHaveBeenCalledTimes(0);
         });
     });
 });
+
+/* END ARROW KEYS TESTS */
+
+/* BEGIN AUTOWRAP ARROW KEY TESTS */
+
+describe('given 3 items with autoWrap on', function() {
+    function setup() {
+        document.body.innerHTML = `
+            <ul class="widget">
+                <li>Item 1</li>
+                <li>Item 2</li>
+                <li>Item 3</li>
+            </ul>
+        `;
+
+        testEl = document.querySelector('.widget');
+        testEmitter = NavigationEmitter.createLinear(testEl, 'li', { wrap: true }); // eslint-disable-line
+
+        onNavigationModelChange = jasmine.createSpy('onNavigationModelChange');
+        testEl.addEventListener('navigationModelChange', onNavigationModelChange);
+    }
+
+    beforeAll(setup);
+    afterEach(setup);
+
+    describe('when arrow left is pressed once', function() {
+        beforeAll(function() {
+            triggerArrowKeyPress(testEl, 'Left', 1);
+        });
+
+        it('should trigger 1 navigationModelChange event', function() {
+            expect(onNavigationModelChange).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('when arrow up is pressed once', function() {
+        beforeAll(function() {
+            triggerArrowKeyPress(testEl, 'Up', 1);
+        });
+
+        it('should trigger 1 navigationModelChange event', function() {
+            expect(onNavigationModelChange).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('when arrow right is pressed once', function() {
+        beforeAll(function() {
+            triggerArrowKeyPress(testEl, 'Right', 1);
+        });
+
+        it('should trigger 1 navigationModelChange event', function() {
+            expect(onNavigationModelChange).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('when arrow right is pressed twice', function() {
+        beforeAll(function() {
+            triggerArrowKeyPress(testEl, 'Right', 2);
+        });
+
+        it('should trigger 1 navigationModelChange event', function() {
+            expect(onNavigationModelChange).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('when arrow right is pressed three times', function() {
+        beforeAll(function() {
+            triggerArrowKeyPress(testEl, 'Right', 3);
+        });
+
+        it('should trigger 1 navigationModelChange event', function() {
+            expect(onNavigationModelChange).toHaveBeenCalledTimes(3);
+        });
+    });
+
+    describe('when arrow down is pressed once', function() {
+        beforeAll(function() {
+            triggerArrowKeyPress(testEl, 'Down', 1);
+        });
+
+        it('should trigger 1 navigationModelChange event', function() {
+            expect(onNavigationModelChange).toHaveBeenCalledTimes(1);
+        });
+    });
+});
+
+/* END AUTOWRAP ARROW KEYS TESTS */
+
+/* BEGIN INDEX SETTER TESTS */
+
+describe('given 3 items with default options', function() {
+    function setup() {
+        document.body.innerHTML = `
+            <ul class="widget">
+                <li>Item 1</li>
+                <li>Item 2</li>
+                <li>Item 3</li>
+            </ul>
+        `;
+
+        testEl = document.querySelector('.widget');
+        testEmitter = NavigationEmitter.createLinear(testEl, 'li'); // eslint-disable-line
+
+        onNavigationModelChange = jasmine.createSpy('onNavigationModelChange');
+        testEl.addEventListener('navigationModelChange', onNavigationModelChange);
+    }
+
+    beforeAll(setup);
+    afterEach(setup);
+
+    describe('when index set to current index', function() {
+        beforeEach(function() {
+            testEmitter.model.index = 0;
+        });
+
+        it('should trigger 0 navigationModelChange event', function() {
+            expect(onNavigationModelChange).toHaveBeenCalledTimes(0);
+        });
+    });
+
+    describe('when index set within bounds', function() {
+        beforeEach(function() {
+            testEmitter.model.index = 1;
+        });
+
+        it('should trigger 1 navigationModelChange event', function() {
+            expect(onNavigationModelChange).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('when index set out of bounds', function() {
+        beforeEach(function() {
+            testEmitter.model.index = 100;
+        });
+
+        it('should trigger 0 navigationModelChange events', function() {
+            expect(onNavigationModelChange).toHaveBeenCalledTimes(0);
+        });
+    });
+});
+
+/* END INDEX SETTER TESTS */


### PR DESCRIPTION
Prequel to #99 

I wanted to add some tests for hidden items, before I delve into adding support for disabled items. In the process of doing this I refactored the existing tests and started to come up with something resembling a convention around "[Given, when, then](https://martinfowler.com/bliki/GivenWhenThen.html)". The main idea that the "Given" is the main setup of DOM and widget instance. The "when" is when something is executed (trying to keep this to just *one* thing that gets executed, e.g. a key press). The "then" is the assertion (also trying to keep this to just *one* `expect()` per assertion to keep things readable in bite size chunks. Nobody likes figuring out long & cryptic test assertions!

@saiponnada If you approve of this approach, you could adopt it in #98.

Some of this code does not follow DRY principles. For example, the innerHTML in each setup. However, I wanted to keep it a little more readable for now, without needing to go lookup too many references, and so I don't mind the repetition. We can perhaps improve on this aspect later.

Another thing we could do is separate out each logical group of tests to their own test file.

Definitely still not the exhaustive list of tests for navigation emitter, but it moves things forward.