### PR TITLE
chore: removed deprecated xlink in svg use tags

### DIFF
--- a/docs/makeup-combobox/index.html
+++ b/docs/makeup-combobox/index.html
@@ -39,7 +39,7 @@
                 aria-owns="listbox-1"
               />
               <svg class="icon icon--chevron-down-12" focusable="false" height="12" width="12" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-chevron-down-12"></use>
+                <use href="../icons.svg#icon-chevron-down-12"></use>
               </svg>
             </span>
             <div class="combobox__listbox" hidden>
@@ -92,7 +92,7 @@
                 aria-owns="listbox-2"
               />
               <svg class="icon icon--chevron-down-12" focusable="false" height="12" width="12" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-chevron-down-12"></use>
+                <use href="../icons.svg#icon-chevron-down-12"></use>
               </svg>
             </span>
             <div class="combobox__listbox" hidden>
@@ -143,7 +143,7 @@
                 aria-owns="listbox-3"
               />
               <svg class="icon icon--chevron-down-12" focusable="false" height="12" width="12" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-chevron-down-12"></use>
+                <use href="../icons.svg#icon-chevron-down-12"></use>
               </svg>
             </span>
             <div class="combobox__listbox" hidden>
@@ -194,7 +194,7 @@
                 aria-owns="listbox-4"
               />
               <svg class="icon icon--chevron-down-12" focusable="false" height="12" width="12" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-chevron-down-12"></use>
+                <use href="../icons.svg#icon-chevron-down-12"></use>
               </svg>
             </span>
             <div class="combobox__listbox" hidden>

--- a/docs/makeup-dialog-button/index.html
+++ b/docs/makeup-dialog-button/index.html
@@ -38,7 +38,7 @@
               <h2 id="lightbox-dialog-title">Lightbox Dialog</h2>
               <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                  <use xlink:href="../icons.svg#icon-close"></use>
+                  <use href="../icons.svg#icon-close"></use>
                 </svg>
               </button>
             </div>
@@ -166,7 +166,7 @@
               <h2 id="panel-dialog-title">Heading</h2>
               <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                  <use xlink:href="../icons.svg#icon-close"></use>
+                  <use href="../icons.svg#icon-close"></use>
                 </svg>
               </button>
             </div>
@@ -191,7 +191,7 @@
                         <div class="panel-dialog__header">
                             <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
                                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                                    <use xlink:href="../icons.svg#icon-close"></use>
+                                    <use href="../icons.svg#icon-close"></use>
                                 </svg>
                             </button>
                             <h2 id="filter-dialog-title" class="panel-dialog__title panel-dialog__title--center">Filter</h2>
@@ -214,7 +214,7 @@
                         <div class="panel-dialog__header">
                             <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
                                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                                    <use xlink:href="../icons.svg#icon-close"></use>
+                                    <use href="../icons.svg#icon-close"></use>
                                 </svg>
                             </button>
                             <h2 id="sort-dialog-title" class="panel-dialog__title panel-dialog__title--center">Sort</h2>
@@ -277,7 +277,7 @@
                 aria-label="Close notification dialog"
               >
                 <svg class="icon icon--close" focusable="false" height="24" width="24">
-                  <use xlink:href="../icons.svg#icon-close"></use>
+                  <use href="../icons.svg#icon-close"></use>
                 </svg>
               </button>
             </div>
@@ -309,7 +309,7 @@
               <h2 id="drawer-dialog-title" class="large-text-1 bold-text">Drawer Dialog</h2>
               <button aria-label="Close dialog" class="icon-btn drawer-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                  <use xlink:href="../icons.svg#icon-close"></use>
+                  <use href="../icons.svg#icon-close"></use>
                 </svg>
               </button>
             </div>
@@ -369,7 +369,7 @@
             <div class="fullscreen-dialog__header">
               <button aria-label="Close dialog" class="icon-btn fullscreen-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                  <use xlink:href="../icons.svg#icon-close"></use>
+                  <use href="../icons.svg#icon-close"></use>
                 </svg>
               </button>
               <h2 id="fullscreen-dialog-title">Fullscreen Dialog</h2>

--- a/docs/makeup-drawer-dialog/index.html
+++ b/docs/makeup-drawer-dialog/index.html
@@ -33,7 +33,7 @@
               <h2 id="drawer-dialog-title" class="large-text-1 bold-text">Drawer Dialog</h2>
               <button aria-label="Close dialog" class="icon-btn drawer-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close-16" focusable="false" height="16" width="16">
-                  <use xlink:href="../icons.svg#icon-close-16"></use>
+                  <use href="../icons.svg#icon-close-16"></use>
                 </svg>
               </button>
             </div>

--- a/docs/makeup-fullscreen-dialog/index.html
+++ b/docs/makeup-fullscreen-dialog/index.html
@@ -32,7 +32,7 @@
             <div class="fullscreen-dialog__header">
               <button aria-label="Close dialog" class="icon-btn fullscreen-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close-16" focusable="false" height="16" width="16">
-                  <use xlink:href="../icons.svg#icon-close-16"></use>
+                  <use href="../icons.svg#icon-close-16"></use>
                 </svg>
               </button>
               <h2 id="fullscreen-dialog-title">Fullscreen Dialog</h2>

--- a/docs/makeup-lightbox-dialog/index.html
+++ b/docs/makeup-lightbox-dialog/index.html
@@ -33,7 +33,7 @@
               <h2 id="lightbox-dialog-title">Lightbox Dialog</h2>
               <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close-16" focusable="false" height="16" width="16">
-                  <use xlink:href="../icons.svg#icon-close-16"></use>
+                  <use href="../icons.svg#icon-close-16"></use>
                 </svg>
               </button>
             </div>

--- a/docs/makeup-listbox-button/index.html
+++ b/docs/makeup-listbox-button/index.html
@@ -39,7 +39,7 @@
             <span class="btn__cell">
               <span class="btn__text">Color: -</span>
               <svg class="icon icon--chevron-down-12" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-chevron-down-12"></use>
+                <use href="../icons.svg#icon-chevron-down-12"></use>
               </svg>
             </span>
           </button>
@@ -48,25 +48,25 @@
               <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Blue</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option" aria-disabled="true">
                 <span class="listbox-button__value">Yellow</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
             </div>
@@ -86,7 +86,7 @@
             <span class="btn__cell">
               <span class="btn__text">Color: Blue</span>
               <svg class="icon icon--chevron-down-12" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-chevron-down-12"></use>
+                <use href="../icons.svg#icon-chevron-down-12"></use>
               </svg>
             </span>
           </button>
@@ -95,25 +95,25 @@
               <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option" aria-selected="true">
                 <span class="listbox-button__value">Blue</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option" aria-disabled="true">
                 <span class="listbox-button__value">Yellow</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
             </div>
@@ -131,7 +131,7 @@
               <span class="btn__floating-label">Color</span>
               <span class="btn__text"></span>
               <svg class="icon icon--chevron-down-12" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-chevron-down-12"></use>
+                <use href="../icons.svg#icon-chevron-down-12"></use>
               </svg>
             </span>
           </button>
@@ -140,31 +140,31 @@
               <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value"></span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Blue</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option" aria-disabled="true">
                 <span class="listbox-button__value">Yellow</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
             </div>
@@ -191,7 +191,7 @@
             <span class="btn__cell">
               <span class="btn__text">Color: -</span>
               <svg class="icon icon--chevron-down-12" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-chevron-down-12"></use>
+                <use href="../icons.svg#icon-chevron-down-12"></use>
               </svg>
             </span>
           </button>
@@ -200,25 +200,25 @@
               <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Blue</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option" aria-disabled="true">
                 <span class="listbox-button__value">Yellow</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
             </div>
@@ -238,7 +238,7 @@
             <span class="btn__cell">
               <span class="btn__text">Color: Blue</span>
               <svg class="icon icon--chevron-down-12" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-chevron-down-12"></use>
+                <use href="../icons.svg#icon-chevron-down-12"></use>
               </svg>
             </span>
           </button>
@@ -247,25 +247,25 @@
               <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option" aria-selected="true">
                 <span class="listbox-button__value">Blue</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option" aria-disabled="true">
                 <span class="listbox-button__value">Yellow</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
             </div>
@@ -285,7 +285,7 @@
               <span class="btn__floating-label">Color</span>
               <span class="btn__text"></span>
               <svg class="icon icon--chevron-down-12" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-chevron-down-12"></use>
+                <use href="../icons.svg#icon-chevron-down-12"></use>
               </svg>
             </span>
           </button>
@@ -294,31 +294,31 @@
               <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value"></span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Blue</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option" aria-disabled="true">
                 <span class="listbox-button__value">Yellow</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
             </div>
@@ -338,7 +338,7 @@
             <span class="btn__cell">
               <span class="btn__text">Color: -</span>
               <svg class="icon icon--chevron-down-12" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-chevron-down-12"></use>
+                <use href="../icons.svg#icon-chevron-down-12"></use>
               </svg>
             </span>
           </button>
@@ -348,28 +348,28 @@
                 <span class="listbox-button__value">Red</span>
                 <span class="listbox-button__description"><span class="clipped">.</span>More information about Red</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Blue</span>
                 <span class="listbox-button__description"><span class="clipped">.</span>More information about Blue</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option" aria-disabled="true">
                 <span class="listbox-button__value">Yellow</span>
                 <span class="listbox-button__description"><span class="clipped">.</span>More information about Yellow</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
                 <span class="listbox-button__description"><span class="clipped">.</span>More information about Green</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
             </div>

--- a/docs/makeup-listbox/index.html
+++ b/docs/makeup-listbox/index.html
@@ -43,25 +43,25 @@
           <div class="listbox__option" role="option" aria-selected="false">
             <span class="listbox__value">Red</span>
             <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-              <use xlink:href="../icons.svg#icon-tick-16"></use>
+              <use href="../icons.svg#icon-tick-16"></use>
             </svg>
           </div>
           <div class="listbox__option" role="option" aria-selected="false">
             <span class="listbox__value">Blue</span>
             <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-              <use xlink:href="../icons.svg#icon-tick-16"></use>
+              <use href="../icons.svg#icon-tick-16"></use>
             </svg>
           </div>
           <div class="listbox__option" role="option" aria-selected="false" aria-disabled="true">
             <span class="listbox__value">Yellow</span>
             <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-              <use xlink:href="../icons.svg#icon-tick-16"></use>
+              <use href="../icons.svg#icon-tick-16"></use>
             </svg>
           </div>
           <div class="listbox__option" role="option" aria-selected="false">
             <span class="listbox__value">Green</span>
             <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-              <use xlink:href="../icons.svg#icon-tick-16"></use>
+              <use href="../icons.svg#icon-tick-16"></use>
             </svg>
           </div>
         </div>
@@ -74,25 +74,25 @@
           <div class="listbox__option" role="option" aria-selected="false">
             <span class="listbox__value">Red</span>
             <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-              <use xlink:href="../icons.svg#icon-tick-16"></use>
+              <use href="../icons.svg#icon-tick-16"></use>
             </svg>
           </div>
           <div class="listbox__option" role="option" aria-selected="true">
             <span class="listbox__value">Blue</span>
             <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-              <use xlink:href="../icons.svg#icon-tick-16"></use>
+              <use href="../icons.svg#icon-tick-16"></use>
             </svg>
           </div>
           <div class="listbox__option" role="option" aria-selected="false" aria-disabled="true">
             <span class="listbox__value">Yellow</span>
             <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-              <use xlink:href="../icons.svg#icon-tick-16"></use>
+              <use href="../icons.svg#icon-tick-16"></use>
             </svg>
           </div>
           <div class="listbox__option" role="option" aria-selected="false">
             <span class="listbox__value">Green</span>
             <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-              <use xlink:href="../icons.svg#icon-tick-16"></use>
+              <use href="../icons.svg#icon-tick-16"></use>
             </svg>
           </div>
         </div>
@@ -111,25 +111,25 @@
           <div class="listbox__option" role="option" aria-selected="false">
             <span class="listbox__value">Red</span>
             <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-              <use xlink:href="../icons.svg#icon-tick-16"></use>
+              <use href="../icons.svg#icon-tick-16"></use>
             </svg>
           </div>
           <div class="listbox__option" role="option" aria-selected="false">
             <span class="listbox__value">Blue</span>
             <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-              <use xlink:href="../icons.svg#icon-tick-16"></use>
+              <use href="../icons.svg#icon-tick-16"></use>
             </svg>
           </div>
           <div class="listbox__option" role="option" aria-selected="false" aria-disabled="true">
             <span class="listbox__value">Yellow</span>
             <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-              <use xlink:href="../icons.svg#icon-tick-16"></use>
+              <use href="../icons.svg#icon-tick-16"></use>
             </svg>
           </div>
           <div class="listbox__option" role="option" aria-selected="false">
             <span class="listbox__value">Green</span>
             <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-              <use xlink:href="../icons.svg#icon-tick-16"></use>
+              <use href="../icons.svg#icon-tick-16"></use>
             </svg>
           </div>
         </div>
@@ -142,25 +142,25 @@
           <div class="listbox__option" role="option" aria-selected="false">
             <span class="listbox__value">Red</span>
             <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-              <use xlink:href="../icons.svg#icon-tick-16"></use>
+              <use href="../icons.svg#icon-tick-16"></use>
             </svg>
           </div>
           <div class="listbox__option" role="option" aria-selected="true">
             <span class="listbox__value">Blue</span>
             <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-              <use xlink:href="../icons.svg#icon-tick-16"></use>
+              <use href="../icons.svg#icon-tick-16"></use>
             </svg>
           </div>
           <div class="listbox__option" role="option" aria-selected="false" aria-disabled="true">
             <span class="listbox__value">Yellow</span>
             <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-              <use xlink:href="../icons.svg#icon-tick-16"></use>
+              <use href="../icons.svg#icon-tick-16"></use>
             </svg>
           </div>
           <div class="listbox__option" role="option" aria-selected="false">
             <span class="listbox__value">Green</span>
             <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-              <use xlink:href="../icons.svg#icon-tick-16"></use>
+              <use href="../icons.svg#icon-tick-16"></use>
             </svg>
           </div>
         </div>
@@ -174,28 +174,28 @@
             <span class="listbox__value">Red</span>
             <span class="listbox__description"><span class="clipped">.</span>More info about red</span>
             <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-              <use xlink:href="../icons.svg#icon-tick-16"></use>
+              <use href="../icons.svg#icon-tick-16"></use>
             </svg>
           </div>
           <div class="listbox__option" role="option" aria-selected="true">
             <span class="listbox__value">Blue</span>
             <span class="listbox__description"><span class="clipped">.</span>More info about blue</span>
             <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-              <use xlink:href="../icons.svg#icon-tick-16"></use>
+              <use href="../icons.svg#icon-tick-16"></use>
             </svg>
           </div>
           <div class="listbox__option" role="option" aria-selected="false">
             <span class="listbox__value">Yellow</span>
             <span class="listbox__description"><span class="clipped">.</span>More info about yellow</span>
             <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-              <use xlink:href="../icons.svg#icon-tick-16"></use>
+              <use href="../icons.svg#icon-tick-16"></use>
             </svg>
           </div>
           <div class="listbox__option" role="option" aria-selected="false">
             <span class="listbox__value">Green</span>
             <span class="listbox__description"><span class="clipped">.</span>More info about green</span>
             <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-              <use xlink:href="../icons.svg#icon-tick-16"></use>
+              <use href="../icons.svg#icon-tick-16"></use>
             </svg>
         </div>
       </div>

--- a/docs/makeup-menu-button/index.html
+++ b/docs/makeup-menu-button/index.html
@@ -22,7 +22,7 @@
             <span class="btn__cell">
               <span class="btn__text">Button</span>
               <svg class="icon icon--chevron-down-12" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-chevron-down-12"></use>
+                <use href="../icons.svg#icon-chevron-down-12"></use>
               </svg>
             </span>
           </button>
@@ -52,7 +52,7 @@
             <span class="btn__cell">
               <span class="btn__text">Button</span>
               <svg class="icon icon--chevron-down-12" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-chevron-down-12"></use>
+                <use href="../icons.svg#icon-chevron-down-12"></use>
               </svg>
             </span>
           </button>
@@ -61,13 +61,13 @@
               <div class="menu-button__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
                 <span>Menu Item 1</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="menu-button__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
                 <span>Menu Item 2</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div
@@ -79,13 +79,13 @@
               >
                 <span>Menu Item 3</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="menu-button__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
                 <span>Menu Item 4</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
             </div>
@@ -100,7 +100,7 @@
             <span class="btn__cell">
               <span class="btn__text">Button</span>
               <svg class="icon icon--chevron-down-12" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-chevron-down-12"></use>
+                <use href="../icons.svg#icon-chevron-down-12"></use>
               </svg>
             </span>
           </button>
@@ -109,13 +109,13 @@
               <div class="menu-button__item" role="menuitemradio" aria-checked="true" data-makeup-group="sort">
                 <span>Menu Item 1</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="menu-button__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
                 <span>Menu Item 2</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div
@@ -127,13 +127,13 @@
               >
                 <span>Menu Item 3</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="menu-button__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
                 <span>Menu Item 4</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
             </div>
@@ -148,7 +148,7 @@
           <button class="btn" type="button" data-makeup-menu-button-prefix="Sort:">
             <span class="btn__text">Sort: Name</span>
             <svg focusable="false" height="10" width="14" aria-hidden="true">
-              <use xlink:href="../icons.svg#icon-chevron-down-12"></use>
+              <use href="../icons.svg#icon-chevron-down-12"></use>
             </svg>
           </button>
           <div class="menu-button__menu" hidden>
@@ -156,13 +156,13 @@
               <div class="menu-button__item" role="menuitemradio" data-makeup-group="sort" aria-checked="true">
                 <span>Name</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="menu-button__item" role="menuitemradio" data-makeup-group="sort" aria-checked="false">
                 <span>Date</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div
@@ -174,13 +174,13 @@
               >
                 <span>Price</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="menu-button__item" role="menuitemradio" data-makeup-group="sort" aria-checked="false">
                 <span>Time Left</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
             </div>
@@ -195,11 +195,11 @@
           <button class="btn" type="button">
             <span class="btn__text">
               <svg class="icon icon--amex-18-colored" focusable="false" height="18" width="30" aria-label="AMEX">
-                <use xlink:href="../icons.svg#icon-amex-18-colored"></use>
+                <use href="../icons.svg#icon-amex-18-colored"></use>
               </svg>
             </span>
             <svg focusable="false" height="10" width="14" aria-hidden="true">
-              <use xlink:href="../icons.svg#icon-chevron-down-12"></use>
+              <use href="../icons.svg#icon-chevron-down-12"></use>
             </svg>
           </button>
           <div class="menu-button__menu" hidden>
@@ -207,34 +207,34 @@
               <div class="menu-button__item" role="menuitemradio" data-makeup-group="credit-card" aria-checked="true">
                 <div class="menu-button__item-value">
                   <svg class="icon icon--amex-18-colored" focusable="false" height="18" width="30" aria-hidden="true">
-                    <use xlink:href="../icons.svg#icon-amex-18-colored"></use>
+                    <use href="../icons.svg#icon-amex-18-colored"></use>
                   </svg>
                   <span>AMEX</span>
                 </div>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="menu-button__item" role="menuitemradio" data-makeup-group="credit-card" aria-checked="false">
                 <div class="menu-button__item-value">
                   <svg class="icon icon--visa-18-colored" focusable="false" height="18" width="30" aria-hidden="true">
-                    <use xlink:href="../icons.svg#icon-visa-18-colored"></use>
+                    <use href="../icons.svg#icon-visa-18-colored"></use>
                   </svg>
                   <span>VISA</span>
                 </div>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="menu-button__item" role="menuitemradio" data-makeup-group="credit-card" aria-checked="false">
                 <div class="menu-button__item-value">
                   <svg class="icon icon--mastercard-18-colored" focusable="false" height="18" width="30" aria-hidden="true">
-                    <use xlink:href="../icons.svg#icon-mastercard-18-colored"></use>
+                    <use href="../icons.svg#icon-mastercard-18-colored"></use>
                   </svg>
                   <span>Master Card</span>
                 </div>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
             </div>
@@ -249,12 +249,12 @@
           <button class="btn" type="button">
             <span class="btn__text">
               <svg class="icon icon--amex-18-colored" focusable="false" height="18" width="30" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-amex-18-colored"></use>
+                <use href="../icons.svg#icon-amex-18-colored"></use>
               </svg>
               <span>AMEX</span>
             </span>
             <svg focusable="false" height="10" width="14" aria-hidden="true">
-              <use xlink:href="../icons.svg#icon-chevron-down-12"></use>
+              <use href="../icons.svg#icon-chevron-down-12"></use>
             </svg>
           </button>
           <div class="menu-button__menu" hidden>
@@ -262,34 +262,34 @@
               <div class="menu-button__item" role="menuitemradio" data-makeup-group="credit-card" aria-checked="true">
                 <div class="menu-button__item-value">
                   <svg class="icon icon--amex-18-colored" focusable="false" height="18" width="30" aria-hidden="true">
-                    <use xlink:href="../icons.svg#icon-amex-18-colored"></use>
+                    <use href="../icons.svg#icon-amex-18-colored"></use>
                   </svg>
                   <span>AMEX</span>
                 </div>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="menu-button__item" role="menuitemradio" data-makeup-group="credit-card" aria-checked="false">
                 <div class="menu-button__item-value">
                   <svg class="icon icon--visa-18-colored" focusable="false" height="18" width="30" aria-hidden="true">
-                    <use xlink:href="../icons.svg#icon-visa-18-colored"></use>
+                    <use href="../icons.svg#icon-visa-18-colored"></use>
                   </svg>
                   <span>VISA</span>
                 </div>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="menu-button__item" role="menuitemradio" data-makeup-group="credit-card" aria-checked="false">
                 <div class="menu-button__item-value">
                   <svg class="icon icon--mastercard-18-colored" focusable="false" height="18" width="30" aria-hidden="true">
-                    <use xlink:href="../icons.svg#icon-mastercard-18-colored"></use>
+                    <use href="../icons.svg#icon-mastercard-18-colored"></use>
                   </svg>
                   <span>Master Card</span>
                 </div>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
             </div>
@@ -304,7 +304,7 @@
             <span class="btn__cell">
               <span class="btn__text">Button</span>
               <svg class="icon icon--chevron-down-12" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-chevron-down-12"></use>
+                <use href="../icons.svg#icon-chevron-down-12"></use>
               </svg>
             </span>
           </button>
@@ -313,13 +313,13 @@
               <div class="menu-button__item" role="menuitemcheckbox" data-makeup-group="filter" aria-checked="true">
                 <span>Menu Item 1</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="menu-button__item" role="menuitemcheckbox" data-makeup-group="filter" aria-checked="true">
                 <span>Menu Item 2</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div
@@ -331,13 +331,13 @@
               >
                 <span>Menu Item 3</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="menu-button__item" role="menuitemcheckbox" data-makeup-group="filter" aria-checked="false">
                 <span>Menu Item 4</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
             </div>
@@ -352,7 +352,7 @@
             <span class="btn__cell">
               <span class="btn__text">Button</span>
               <svg class="icon icon--chevron-down-12" focusable="false" height="10" width="14"  aria-label="AMEX">
-                <use xlink:href="../icons.svg#icon-chevron-down-12"></use>
+                <use href="../icons.svg#icon-chevron-down-12"></use>
               </svg>
             </span>
           </button>
@@ -367,7 +367,7 @@
               <div class="menu-button__item" role="menuitemradio" aria-checked="true" data-makeup-group="sort">
                 <span>Menu Item B1</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div
@@ -379,13 +379,13 @@
               >
                 <span>Menu Item B2</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="menu-button__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
                 <span>Menu Item B3</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
 
@@ -394,13 +394,13 @@
               <div class="menu-button__item" role="menuitemcheckbox" data-makeup-group="filter" aria-checked="true">
                 <span>Menu Item C1</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
               <div class="menu-button__item" role="menuitemcheckbox" data-makeup-group="filter" aria-checked="true">
                 <span>Menu Item C2</span>
                 <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-tick-16"></use>
+                  <use href="../icons.svg#icon-tick-16"></use>
                 </svg>
               </div>
             </div>

--- a/docs/makeup-menu/index.html
+++ b/docs/makeup-menu/index.html
@@ -50,13 +50,13 @@
             <div class="menu__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
               <span>Item 1</span>
               <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-tick-16"></use>
+                <use href="../icons.svg#icon-tick-16"></use>
               </svg>
             </div>
             <div class="menu__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
               <span>Item 2</span>
               <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-tick-16"></use>
+                <use href="../icons.svg#icon-tick-16"></use>
               </svg>
             </div>
             <div
@@ -68,13 +68,13 @@
             >
               <span>Item 3</span>
               <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-tick-16"></use>
+                <use href="../icons.svg#icon-tick-16"></use>
               </svg>
             </div>
             <div class="menu__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
               <span>Item 4</span>
               <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-tick-16"></use>
+                <use href="../icons.svg#icon-tick-16"></use>
               </svg>
             </div>
           </div>
@@ -87,13 +87,13 @@
             <div class="menu__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
               <span>Item 1</span>
               <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-tick-16"></use>
+                <use href="../icons.svg#icon-tick-16"></use>
               </svg>
             </div>
             <div class="menu__item" role="menuitemradio" aria-checked="true" data-makeup-group="sort">
               <span>Item 2</span>
               <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-tick-16"></use>
+                <use href="../icons.svg#icon-tick-16"></use>
               </svg>
             </div>
             <div
@@ -105,13 +105,13 @@
             >
               <span>Item 3</span>
               <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-tick-16"></use>
+                <use href="../icons.svg#icon-tick-16"></use>
               </svg>
             </div>
             <div class="menu__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
               <span>Item 4</span>
               <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-tick-16"></use>
+                <use href="../icons.svg#icon-tick-16"></use>
               </svg>
             </div>
           </div>
@@ -124,34 +124,34 @@
             <div class="menu__item" role="menuitemradio" data-makeup-group="credit-card" aria-checked="true">
               <div class="menu__item-value">
                 <svg class="icon icon--amex-18-colored" focusable="false" height="18" width="30" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-amex-18-colored"></use>
+                  <use href="../icons.svg#icon-amex-18-colored"></use>
                 </svg>
                 <span>AMEX</span>
               </div>
               <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-tick-16"></use>
+                <use href="../icons.svg#icon-tick-16"></use>
               </svg>
             </div>
             <div class="menu__item" role="menuitemradio" data-makeup-group="credit-card" aria-checked="false">
               <div class="menu__item-value">
                 <svg class="icon icon--visa-18-colored" focusable="false" height="18" width="30" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-visa-18-colored"></use>
+                  <use href="../icons.svg#icon-visa-18-colored"></use>
                 </svg>
                 <span>VISA</span>
               </div>
               <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-tick-16"></use>
+                <use href="../icons.svg#icon-tick-16"></use>
               </svg>
             </div>
             <div class="menu__item" role="menuitemradio" data-makeup-group="credit-card" aria-checked="false">
               <div class="menu__item-value">
                 <svg class="icon icon--mastercard-18-colored" focusable="false" height="18" width="30" aria-hidden="true">
-                  <use xlink:href="../icons.svg#icon-mastercard-18-colored"></use>
+                  <use href="../icons.svg#icon-mastercard-18-colored"></use>
                 </svg>
                 <span>Master Card</span>
               </div>
               <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-tick-16"></use>
+                <use href="../icons.svg#icon-tick-16"></use>
               </svg>
             </div>
           </div>
@@ -163,13 +163,13 @@
             <div class="menu__item" role="menuitemcheckbox" aria-checked="false" data-makeup-group="filter">
               <span>Item 1</span>
               <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-tick-16"></use>
+                <use href="../icons.svg#icon-tick-16"></use>
               </svg>
             </div>
             <div class="menu__item" role="menuitemcheckbox" aria-checked="true" data-makeup-group="filter">
               <span>Item 2</span>
               <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-tick-16"></use>
+                <use href="../icons.svg#icon-tick-16"></use>
               </svg>
             </div>
             <div
@@ -181,13 +181,13 @@
             >
               <span>Item 3</span>
               <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-tick-16"></use>
+                <use href="../icons.svg#icon-tick-16"></use>
               </svg>
             </div>
             <div class="menu__item" role="menuitemcheckbox" aria-checked="false" data-makeup-group="filter">
               <span>Item 4</span>
               <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-tick-16"></use>
+                <use href="../icons.svg#icon-tick-16"></use>
               </svg>
             </div>
           </div>
@@ -205,7 +205,7 @@
             <div class="menu__item" role="menuitemradio" aria-checked="true" data-makeup-group="sort">
               <span>Item B1</span>
               <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-tick-16"></use>
+                <use href="../icons.svg#icon-tick-16"></use>
               </svg>
             </div>
             <div
@@ -217,13 +217,13 @@
             >
               <span>Item B2</span>
               <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-tick-16"></use>
+                <use href="../icons.svg#icon-tick-16"></use>
               </svg>
             </div>
             <div class="menu__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
               <span>Item B3</span>
               <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-tick-16"></use>
+                <use href="../icons.svg#icon-tick-16"></use>
               </svg>
             </div>
 
@@ -232,13 +232,13 @@
             <div class="menu__item" role="menuitemcheckbox" aria-checked="true" data-makeup-group="filter">
               <span>Item C1</span>
               <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-tick-16"></use>
+                <use href="../icons.svg#icon-tick-16"></use>
               </svg>
             </div>
             <div class="menu__item" role="menuitemcheckbox" aria-checked="true" data-makeup-group="filter">
               <span>Item C2</span>
               <svg class="icon icon--tick-16" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../icons.svg#icon-tick-16"></use>
+                <use href="../icons.svg#icon-tick-16"></use>
               </svg>
             </div>
           </div>

--- a/docs/makeup-panel-dialog/index.html
+++ b/docs/makeup-panel-dialog/index.html
@@ -33,7 +33,7 @@
               <h2 id="panel-dialog-title">Heading</h2>
               <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close-16" focusable="false" height="16" width="16">
-                  <use xlink:href="../icons.svg#icon-close-16"></use>
+                  <use href="../icons.svg#icon-close-16"></use>
                 </svg>
               </button>
             </div>

--- a/docs/makeup-toast-dialog/index.html
+++ b/docs/makeup-toast-dialog/index.html
@@ -38,7 +38,7 @@
                 aria-label="Close notification dialog"
               >
                 <svg class="icon icon--close-16" focusable="false" height="16" width="16">
-                  <use xlink:href="../icons.svg#icon-close-16"></use>
+                  <use href="../icons.svg#icon-close-16"></use>
                 </svg>
               </button>
             </div>

--- a/packages/makeup-combobox/README.md
+++ b/packages/makeup-combobox/README.md
@@ -22,7 +22,7 @@ The following markup structure and classnames are required. Any SVG icons can be
       aria-owns="listbox1"
     />
     <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-      <use xlink:href="../style/icon.svg#icon-dropdown"></use>
+      <use href="../style/icon.svg#icon-dropdown"></use>
     </svg>
   </span>
   <div class="combobox__listbox">

--- a/packages/makeup-drawer-dialog/README.md
+++ b/packages/makeup-drawer-dialog/README.md
@@ -23,7 +23,7 @@ The following markup structure and classnames are required. Any SVG icons can be
       <h2 id="drawer-dialog-title">Heading</h2>
       <button aria-label="Close dialog" class="icon-btn drawer-dialog__close" type="button">
         <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-          <use xlink:href="../icon.svg#icon-close"></use>
+          <use href="../icon.svg#icon-close"></use>
         </svg>
       </button>
     </div>

--- a/packages/makeup-fullscreen-dialog/README.md
+++ b/packages/makeup-fullscreen-dialog/README.md
@@ -21,7 +21,7 @@ The following markup structure and classnames are required. Any SVG icons can be
     <div class="fullscreen-dialog__header">
       <button aria-label="Close dialog" class="icon-btn fullscreen-dialog__close" type="button">
         <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-          <use xlink:href="../icon.svg#icon-close"></use>
+          <use href="../icon.svg#icon-close"></use>
         </svg>
       </button>
       <h2 id="fullscreen-dialog-title">Fullscreen Dialog</h2>

--- a/packages/makeup-lightbox-dialog/README.md
+++ b/packages/makeup-lightbox-dialog/README.md
@@ -22,7 +22,7 @@ The following markup structure and classnames are required. Any SVG icons can be
       <h2 id="lightbox-dialog-title">Lightbox Dialog</h2>
       <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
         <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-          <use xlink:href="../icon.svg#icon-close"></use>
+          <use href="../icon.svg#icon-close"></use>
         </svg>
       </button>
     </div>

--- a/packages/makeup-listbox-button/README.md
+++ b/packages/makeup-listbox-button/README.md
@@ -14,7 +14,7 @@ The following markup structure and classnames are required. Any SVG icons can be
     <span class="expand-btn__cell">
       <span class="expand-btn__text">Option 1</span>
       <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-        <use xlink:href="icon.svg#icon-dropdown"></use>
+        <use href="icon.svg#icon-dropdown"></use>
       </svg>
     </span>
   </button>
@@ -23,19 +23,19 @@ The following markup structure and classnames are required. Any SVG icons can be
       <div class="listbox-button__option" role="option">
         <span class="listbox-button__value">Option 1</span>
         <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-          <use xlink:href="icon.svg#icon-tick-small"></use>
+          <use href="icon.svg#icon-tick-small"></use>
         </svg>
       </div>
       <div class="listbox-button__option" role="option">
         <span class="listbox-button__value">Option 2</span>
         <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-          <use xlink:href="icon.svg#icon-tick-small"></use>
+          <use href="icon.svg#icon-tick-small"></use>
         </svg>
       </div>
       <div class="listbox-button__option" role="option">
         <span class="listbox-button__value">Option 3</span>
         <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-          <use xlink:href="icon.svg#icon-tick-small"></use>
+          <use href="icon.svg#icon-tick-small"></use>
         </svg>
       </div>
     </div>

--- a/packages/makeup-listbox/README.md
+++ b/packages/makeup-listbox/README.md
@@ -17,7 +17,7 @@ The following markup structure and classnames are required. Any SVG icons can be
       <span class="listbox__value">Option 1</span>
       <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
         <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-          <use xlink:href="icon.svg#icon-tick-small"></use>
+          <use href="icon.svg#icon-tick-small"></use>
         </svg>
       </svg>
     </div>
@@ -25,7 +25,7 @@ The following markup structure and classnames are required. Any SVG icons can be
       <span class="listbox__value">Option 2</span>
       <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
         <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-          <use xlink:href="icon.svg#icon-tick-small"></use>
+          <use href="icon.svg#icon-tick-small"></use>
         </svg>
       </svg>
     </div>
@@ -33,7 +33,7 @@ The following markup structure and classnames are required. Any SVG icons can be
       <span class="listbox__value">Option 3</span>
       <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
         <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-          <use xlink:href="icon.svg#icon-tick-small"></use>
+          <use href="icon.svg#icon-tick-small"></use>
         </svg>
       </svg>
     </div>

--- a/packages/makeup-menu-button/README.md
+++ b/packages/makeup-menu-button/README.md
@@ -16,7 +16,7 @@ The following markup structure and classnames are required. Any SVG icons can be
     <span class="expand-btn__cell">
       <span class="expand-btn__text">Button</span>
       <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-        <use xlink:href="icon.svg#icon-dropdown"></use>
+        <use href="icon.svg#icon-dropdown"></use>
       </svg>
     </span>
   </button>
@@ -44,7 +44,7 @@ The following markup structure and classnames are required. Any SVG icons can be
     <span class="expand-btn__cell">
       <span class="expand-btn__text">Button</span>
       <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-        <use xlink:href="icon.svg#icon-dropdown"></use>
+        <use href="icon.svg#icon-dropdown"></use>
       </svg>
     </span>
   </button>
@@ -53,19 +53,19 @@ The following markup structure and classnames are required. Any SVG icons can be
       <div class="menu-button__item" role="menuitemradio" aria-checked="true" data-makeup-group="sort">
         <span>Menu Item 1</span>
         <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
-          <use xlink:href="icon.svg#icon-tick-small"></use>
+          <use href="icon.svg#icon-tick-small"></use>
         </svg>
       </div>
       <div class="menu-button__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
         <span>Menu Item 2</span>
         <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
-          <use xlink:href="icon.svg#icon-tick-small"></use>
+          <use href="icon.svg#icon-tick-small"></use>
         </svg>
       </div>
       <div class="menu-button__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
         <span>Menu Item 3</span>
         <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
-          <use xlink:href="icon.svg#icon-tick-small"></use>
+          <use href="icon.svg#icon-tick-small"></use>
         </svg>
       </div>
     </div>
@@ -81,7 +81,7 @@ The following markup structure and classnames are required. Any SVG icons can be
     <span class="expand-btn__cell">
       <span class="expand-btn__text">Button</span>
       <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-        <use xlink:href="icon.svg#icon-dropdown"></use>
+        <use href="icon.svg#icon-dropdown"></use>
       </svg>
     </span>
   </button>
@@ -90,19 +90,19 @@ The following markup structure and classnames are required. Any SVG icons can be
       <div class="menu-button__item" role="menuitemcheckbox" data-makeup-group="filter" aria-checked="true">
         <span>Menu Item 1</span>
         <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
-          <use xlink:href="icon.svg#icon-tick-small"></use>
+          <use href="icon.svg#icon-tick-small"></use>
         </svg>
       </div>
       <div class="menu-button__item" role="menuitemcheckbox" data-makeup-group="filter" aria-checked="true">
         <span>Menu Item 2</span>
         <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
-          <use xlink:href="icon.svg#icon-tick-small"></use>
+          <use href="icon.svg#icon-tick-small"></use>
         </svg>
       </div>
       <div class="menu-button__item" role="menuitemcheckbox" data-makeup-group="filter" aria-checked="false">
         <span>Menu Item 3</span>
         <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
-          <use xlink:href="icon.svg#icon-tick-small"></use>
+          <use href="icon.svg#icon-tick-small"></use>
         </svg>
       </div>
     </div>
@@ -118,7 +118,7 @@ The following markup structure and classnames are required. Any SVG icons can be
     <span class="expand-btn__cell">
       <span class="expand-btn__text">Button</span>
       <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-        <use xlink:href="icon.svg#icon-dropdown"></use>
+        <use href="icon.svg#icon-dropdown"></use>
       </svg>
     </span>
   </button>
@@ -133,19 +133,19 @@ The following markup structure and classnames are required. Any SVG icons can be
       <div class="menu-button__item" role="menuitemradio" aria-checked="true" data-makeup-group="sort">
         <span>Menu Item B1</span>
         <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
-          <use xlink:href="icon.svg#icon-tick-small"></use>
+          <use href="icon.svg#icon-tick-small"></use>
         </svg>
       </div>
       <div class="menu-button__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
         <span>Menu Item B2</span>
         <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
-          <use xlink:href="icon.svg#icon-tick-small"></use>
+          <use href="icon.svg#icon-tick-small"></use>
         </svg>
       </div>
       <div class="menu-button__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
         <span>Menu Item B3</span>
         <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
-          <use xlink:href="icon.svg#icon-tick-small"></use>
+          <use href="icon.svg#icon-tick-small"></use>
         </svg>
       </div>
 
@@ -154,13 +154,13 @@ The following markup structure and classnames are required. Any SVG icons can be
       <div class="menu-button__item" role="menuitemcheckbox" data-makeup-group="filter" aria-checked="true">
         <span>Menu Item C1</span>
         <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
-          <use xlink:href="icon.svg#icon-tick-small"></use>
+          <use href="icon.svg#icon-tick-small"></use>
         </svg>
       </div>
       <div class="menu-button__item" role="menuitemcheckbox" data-makeup-group="filter" aria-checked="true">
         <span>Menu Item C2</span>
         <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
-          <use xlink:href="icon.svg#icon-tick-small"></use>
+          <use href="icon.svg#icon-tick-small"></use>
         </svg>
       </div>
     </div>

--- a/packages/makeup-menu/README.md
+++ b/packages/makeup-menu/README.md
@@ -34,19 +34,19 @@ The following markup structure and classnames are required. Any SVG icons can be
     <div class="menu__item" role="menuitemradio" aria-checked="true" data-menuitemradio-name="sort">
       <span>Item 1</span>
       <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
-        <use xlink:href="icon.svg#icon-tick-small"></use>
+        <use href="icon.svg#icon-tick-small"></use>
       </svg>
     </div>
     <div class="menu__item" role="menuitemradio" aria-checked="false" data-menuitemradio-name="sort">
       <span>Item 2</span>
       <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
-        <use xlink:href="icon.svg#icon-tick-small"></use>
+        <use href="icon.svg#icon-tick-small"></use>
       </svg>
     </div>
     <div class="menu__item" role="menuitemradio" aria-checked="false" data-menuitemradio-name="sort">
       <span>Item 3</span>
       <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
-        <use xlink:href="icon.svg#icon-tick-small"></use>
+        <use href="icon.svg#icon-tick-small"></use>
       </svg>
     </div>
   </div>
@@ -61,19 +61,19 @@ The following markup structure and classnames are required. Any SVG icons can be
     <div class="menu__item" role="menuitemcheckbox" aria-checked="true" data-menuitemcheckbox-name="filter">
       <span>Item 1</span>
       <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
-        <use xlink:href="icon.svg#icon-tick-small"></use>
+        <use href="icon.svg#icon-tick-small"></use>
       </svg>
     </div>
     <div class="menu__item" role="menuitemcheckbox" aria-checked="false" data-menuitemcheckbox-name="sort">
       <span>Item 2</span>
       <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
-        <use xlink:href="icon.svg#icon-tick-small"></use>
+        <use href="icon.svg#icon-tick-small"></use>
       </svg>
     </div>
     <div class="menu__item" role="menuitemcheckbox" aria-checked="false" data-menuitemcheckbox-name="sort">
       <span>Item 3</span>
       <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
-        <use xlink:href="icon.svg#icon-tick-small"></use>
+        <use href="icon.svg#icon-tick-small"></use>
       </svg>
     </div>
   </div>
@@ -94,19 +94,19 @@ The following markup structure and classnames are required. Any SVG icons can be
     <div class="menu__item" role="menuitemradio" aria-checked="true" data-makeup-group="sort">
       <span>Item B1</span>
       <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
-        <use xlink:href="icon.svg#icon-tick-small"></use>
+        <use href="icon.svg#icon-tick-small"></use>
       </svg>
     </div>
     <div class="menu__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
       <span>Item B2</span>
       <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
-        <use xlink:href="icon.svg#icon-tick-small"></use>
+        <use href="icon.svg#icon-tick-small"></use>
       </svg>
     </div>
     <div class="menu__item" role="menuitemradio" aria-checked="false" data-makeup-group="sort">
       <span>Item B3</span>
       <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
-        <use xlink:href="icon.svg#icon-tick-small"></use>
+        <use href="icon.svg#icon-tick-small"></use>
       </svg>
     </div>
 
@@ -115,13 +115,13 @@ The following markup structure and classnames are required. Any SVG icons can be
     <div class="menu__item" role="menuitemcheckbox" aria-checked="true" data-makeup-group="filter">
       <span>Item C1</span>
       <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
-        <use xlink:href="icon.svg#icon-tick-small"></use>
+        <use href="icon.svg#icon-tick-small"></use>
       </svg>
     </div>
     <div class="menu__item" role="menuitemcheckbox" aria-checked="true" data-makeup-group="filter">
       <span>Item C2</span>
       <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
-        <use xlink:href="icon.svg#icon-tick-small"></use>
+        <use href="icon.svg#icon-tick-small"></use>
       </svg>
     </div>
   </div>

--- a/packages/makeup-panel-dialog/README.md
+++ b/packages/makeup-panel-dialog/README.md
@@ -22,7 +22,7 @@ The following markup structure and classnames are required. Any SVG icons can be
       <h2 id="panel-dialog-title">Heading</h2>
       <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
         <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-          <use xlink:href="../icon.svg#icon-close"></use>
+          <use href="../icon.svg#icon-close"></use>
         </svg>
       </button>
     </div>

--- a/packages/makeup-toast-dialog/README.md
+++ b/packages/makeup-toast-dialog/README.md
@@ -23,7 +23,7 @@ The following markup structure and classnames are required. Any SVG icons can be
       <h2 class="toast-dialog__title">User Privacy Preferences</h2>
       <button class="icon-btn toast-dialog__close" type="button" aria-label="Close notification dialog">
         <svg class="icon icon--close" focusable="false" height="24" width="24">
-          <use xlink:href="../icon.svg#icon-close"></use>
+          <use href="../icon.svg#icon-close"></use>
         </svg>
       </button>
     </div>


### PR DESCRIPTION
Fixes #136 

This change request removed the deprecated `xlink` from the SVG use tags across the website. 