### PR TITLE
docs: Fixing "icon-close" references in makeup-dialog-button docs

### DIFF
--- a/docs/makeup-dialog-button/index.html
+++ b/docs/makeup-dialog-button/index.html
@@ -38,7 +38,7 @@
               <h2 id="lightbox-dialog-title">Lightbox Dialog</h2>
               <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                  <use href="../icons.svg#icon-close"></use>
+                  <use href="../icons.svg#icon-close-16"></use>
                 </svg>
               </button>
             </div>
@@ -166,7 +166,7 @@
               <h2 id="panel-dialog-title">Heading</h2>
               <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                  <use href="../icons.svg#icon-close"></use>
+                  <use href="../icons.svg#icon-close-16"></use>
                 </svg>
               </button>
             </div>
@@ -191,7 +191,7 @@
                         <div class="panel-dialog__header">
                             <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
                                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                                    <use href="../icons.svg#icon-close"></use>
+                                    <use href="../icons.svg#icon-close-16"></use>
                                 </svg>
                             </button>
                             <h2 id="filter-dialog-title" class="panel-dialog__title panel-dialog__title--center">Filter</h2>
@@ -214,7 +214,7 @@
                         <div class="panel-dialog__header">
                             <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
                                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                                    <use href="../icons.svg#icon-close"></use>
+                                    <use href="../icons.svg#icon-close-16"></use>
                                 </svg>
                             </button>
                             <h2 id="sort-dialog-title" class="panel-dialog__title panel-dialog__title--center">Sort</h2>
@@ -277,7 +277,7 @@
                 aria-label="Close notification dialog"
               >
                 <svg class="icon icon--close" focusable="false" height="24" width="24">
-                  <use href="../icons.svg#icon-close"></use>
+                  <use href="../icons.svg#icon-close-24"></use>
                 </svg>
               </button>
             </div>
@@ -309,7 +309,7 @@
               <h2 id="drawer-dialog-title" class="large-text-1 bold-text">Drawer Dialog</h2>
               <button aria-label="Close dialog" class="icon-btn drawer-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                  <use href="../icons.svg#icon-close"></use>
+                  <use href="../icons.svg#icon-close-16"></use>
                 </svg>
               </button>
             </div>
@@ -369,7 +369,7 @@
             <div class="fullscreen-dialog__header">
               <button aria-label="Close dialog" class="icon-btn fullscreen-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                  <use href="../icons.svg#icon-close"></use>
+                  <use href="../icons.svg#icon-close-16"></use>
                 </svg>
               </button>
               <h2 id="fullscreen-dialog-title">Fullscreen Dialog</h2>


### PR DESCRIPTION
Just a quick fix for the close button in the docs at https://makeup.github.io/makeup-js/makeup-dialog-button/index.html.

Noticed it wasn't appearing and it looks like it wast just a minor regression from daee035. Before/after below.  Picked either `-16` or `-24` depending on the intrinsic size of the `<svg>`.

![image](https://github.com/makeup/makeup-js/assets/4269377/a7ec058a-d330-4a65-9451-79144b040d2f)

![image](https://github.com/makeup/makeup-js/assets/4269377/d3171423-49b7-4084-a422-9da8abbc39dc)