### PR TITLE
docs: Fixing nested <svg>'s in makeup-listbox.

### DIFF
--- a/packages/makeup-listbox/README.md
+++ b/packages/makeup-listbox/README.md
@@ -16,25 +16,19 @@ The following markup structure and classnames are required. Any SVG icons can be
     <div class="listbox__option" role="option" aria-selected="false">
       <span class="listbox__value">Option 1</span>
       <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-        <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-          <use href="icon.svg#icon-tick-small"></use>
-        </svg>
+        <use href="icon.svg#icon-tick-small"></use>
       </svg>
     </div>
     <div class="listbox__option" role="option" aria-selected="false">
       <span class="listbox__value">Option 2</span>
       <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-        <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-          <use href="icon.svg#icon-tick-small"></use>
+        <use href="icon.svg#icon-tick-small"></use>
         </svg>
-      </svg>
     </div>
     <div class="listbox__option" role="option" aria-selected="false">
       <span class="listbox__value">Option 3</span>
       <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-        <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-          <use href="icon.svg#icon-tick-small"></use>
-        </svg>
+        <use href="icon.svg#icon-tick-small"></use>
       </svg>
     </div>
   </div>


### PR DESCRIPTION
Super minor; just happened to notice this in the docks for `makeup-listbox`.

```html
      <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
        <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
          <use href="icon.svg#icon-tick-small"></use>
        </svg>
      </svg>
```