### PR TITLE
Use Lerna watch

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -1,0 +1,1 @@
+packages/*/dist/

--- a/package.json
+++ b/package.json
@@ -1,11 +1,9 @@
 {
     "name": "root",
     "private": true,
-    "workspaces": {
-        "packages": [
-            "packages/*"
-        ]
-    },
+    "workspaces": [
+        "packages/*"
+    ],
     "scripts": {
         "build": "npm run lint && npm run compile && npm run bundle",
         "bundle": "webpack",
@@ -17,7 +15,9 @@
         "server": "browser-sync start -s --ss docs --index docs/index.html --files docs/**/index.html docs/**/index.min.js",
         "start": "npm run build && run-p server watch",
         "test": "karma start --autoWatch false --singleRun true",
-        "watch": "onchange packages/**/src/*.js docs/**/index.js -- npm run build"
+        "watch": "run-p watch:docs watch:packages",
+        "watch:packages": "lerna watch -- 'lerna run compile --scope=$LERNA_PACKAGE_NAME --include-dependents && npm run bundle'",
+        "watch:docs": "onchange docs/**/index.js -- run-s compile:docs bundle"
     },
     "devDependencies": {
         "@babel/cli": "^7.24.1",


### PR DESCRIPTION
I know we are ultimately moving away from all of these little micro packages (once I figure out the backwards compatibility for Lasso), but I've been learning about some newish tricks with Lerna and NPM workspaces and wanted to apply them:

`"watch:packages": "lerna watch -- 'lerna run compile --scope=$LERNA_PACKAGE_NAME --include-dependents && npm run bundle'"`

This is cool. Only the changed package and any dependencies will be recompiled when a file is edited. Vastly speeds up local development time. We are still rebuilding and rebundling all docs though, so that can still be improved.

After an edit to screenreader-trap, see the cascade:

<img width="801" alt="Screenshot 2024-04-18 at 3 04 18 PM" src="https://github.com/makeup/makeup-js/assets/38065/29c395d1-2aaf-4835-815c-467719e451f5">

<strike>
Commit 2: Use asterisk in dependencies

Instead of specifying a version we can just use asterisk. The saves the tedious chore of going and updating version numbers. Not sure why I didn't do this earlier. 
</strike>