### PR TITLE
fix(docs): listbox accidentally nested inside of another listbox

### DIFF
--- a/docs/ui/makeup-listbox-button/index.html
+++ b/docs/ui/makeup-listbox-button/index.html
@@ -119,55 +119,56 @@
               </div>
             </div>
           </div>
-          <h3>Unselected, Floating label</h3>
+        </div>
 
-          <div class="listbox-button" data-makeup-auto-select="false">
-            <button
-              class="btn btn--form btn--floating-label"
-              style="min-width: 175px"
-              aria-expanded="false"
-              aria-haspopup="listbox"
-            >
-              <span class="btn__cell">
-                <span class="btn__floating-label">Color</span>
-                <span class="btn__text"></span>
-                <svg class="icon icon--chevron-down-12" focusable="false" height="10" width="14" aria-hidden="true">
-                  <use href="../../icons.svg#icon-chevron-down-12"></use>
+        <h3>Unselected, Floating label</h3>
+
+        <div class="listbox-button" data-makeup-auto-select="false">
+          <button
+            class="btn btn--form btn--floating-label"
+            style="min-width: 175px"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+          >
+            <span class="btn__cell">
+              <span class="btn__floating-label">Color</span>
+              <span class="btn__text"></span>
+              <svg class="icon icon--chevron-down-12" focusable="false" height="10" width="14" aria-hidden="true">
+                <use href="../../icons.svg#icon-chevron-down-12"></use>
+              </svg>
+            </span>
+          </button>
+          <div class="listbox-button__listbox" hidden>
+            <div class="listbox-button__options" role="listbox">
+              <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value"></span>
+                <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                  <use href="../../icons.svg#icon-tick-16"></use>
                 </svg>
-              </span>
-            </button>
-            <div class="listbox-button__listbox" hidden>
-              <div class="listbox-button__options" role="listbox">
-                <div class="listbox-button__option" role="option">
-                  <span class="listbox-button__value"></span>
-                  <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                    <use href="../../icons.svg#icon-tick-16"></use>
-                  </svg>
-                </div>
-                <div class="listbox-button__option" role="option">
-                  <span class="listbox-button__value">Red</span>
-                  <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                    <use href="../../icons.svg#icon-tick-16"></use>
-                  </svg>
-                </div>
-                <div class="listbox-button__option" role="option">
-                  <span class="listbox-button__value">Blue</span>
-                  <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                    <use href="../../icons.svg#icon-tick-16"></use>
-                  </svg>
-                </div>
-                <div class="listbox-button__option" role="option" aria-disabled="true">
-                  <span class="listbox-button__value">Yellow</span>
-                  <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                    <use href="../../icons.svg#icon-tick-16"></use>
-                  </svg>
-                </div>
-                <div class="listbox-button__option" role="option">
-                  <span class="listbox-button__value">Green</span>
-                  <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                    <use href="../../icons.svg#icon-tick-16"></use>
-                  </svg>
-                </div>
+              </div>
+              <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Red</span>
+                <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                  <use href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+              <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Blue</span>
+                <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                  <use href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+              <div class="listbox-button__option" role="option" aria-disabled="true">
+                <span class="listbox-button__value">Yellow</span>
+                <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                  <use href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+              <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Green</span>
+                <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                  <use href="../../icons.svg#icon-tick-16"></use>
+                </svg>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Fixes this issue below at https://makeup.github.io/makeup-js/ui/makeup-listbox-button/index.html.

Essentially, the `Unselected, Floating label` box was nested _inside of_ the `Selected` box in the `Manual Selection` section. Say that 10 times fast.

![image](https://github.com/makeup/makeup-js/assets/4269377/12cdcc71-d219-48cc-b021-0f57e5da9afc)
