### PR TITLE
fix: prevent browser-sync from opening the browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "compile:modules": "lerna run compile",
     "format": "prettier --write .",
     "lint": "eslint packages/*/*/src/*.js",
-    "server": "browser-sync start -s --ss docs --index docs/index.html --files docs/**/index.html docs/**/index.min.js",
+    "server": "browser-sync start --no-open -s --ss docs --index docs/index.html --files docs/**/index.html docs/**/index.min.js",
     "start": "npm run build && run-p server watch",
     "test": "karma start --autoWatch false --singleRun true",
     "watch": "run-p watch:docs watch:packages",


### PR DESCRIPTION
Or, the wrong browser in my case. My instance of WSL2 has Chromium already installed for testing purposes (for Percy VQA regression testing). Unlike `vite` which launches my host machine's Chrome instances, `browser-sync` appears to not be able to properly determine which browser to use (and it's next to impossible to Google how to configure this thanks to the ambiguity of the name).

So, this just disables it. It's slow and _very_ clunky and I have to manually close it every time I start webpack. 😅 

![image](https://github.com/makeup/makeup-js/assets/4269377/c6582fba-7bb8-4ec5-858f-b2e018445046)
