### PR TITLE
chore: update coveralls workflow to fetch commit history

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js 18.x
         uses: actions/setup-node@v1


### PR DESCRIPTION
## Problem
In the context of GitHub Actions, the `actions/checkout` action supports the fetch-depth parameter to control how much history is fetched when checking out the repository. Default value of `fetch-depth` is `1` which gives access to only latest commit.

## Solution
But, Coveralls needs to access the commit history to generate accurate coverage reports and associate them with the correct commits. If only the latest commit is fetched (fetch-depth: 1), Coveralls might not be able to find the necessary commit information, leading to errors like "[Not a valid object name.](https://github.com/makeup/makeup-js/pull/185/checks)" Hence setting to `0` to fetch entire commit history.