### PR TITLE
fix(expander): add null check for no focusables case

### DIFF
--- a/packages/core/makeup-expander/src/index.js
+++ b/packages/core/makeup-expander/src/index.js
@@ -90,9 +90,9 @@ function manageFocus(focusManagement, contentEl) {
     contentEl.setAttribute("tabindex", "-1");
     contentEl.focus();
   } else if (focusManagement === "focusable") {
-    focusables(contentEl)[0].focus();
+    focusables(contentEl)[0]?.focus();
   } else if (focusManagement === "interactive") {
-    focusables(contentEl, true)[0].focus();
+    focusables(contentEl, true)[0]?.focus();
   } else if (focusManagement !== null) {
     const el = contentEl.querySelector(`#${focusManagement}`);
     if (el) {


### PR DESCRIPTION
For cases where there are no focusables found, add a null check to catch this case before trying to focus on a first element that does not exist.

Issue was observed by users testing in jsdom (where `makeup-focusables` was not detecting elements due to this line always being false: https://github.com/mkchang/makeup-js/blob/66c20dd369c3da6b04e522b1e40946b4af61922a/packages/core/makeup-focusables/src/index.js#L34).