### PR TITLE
feat(listbox, listbox-button): adding listbox and listbox-button examples with group headers

### DIFF
--- a/docs/ui/makeup-listbox-button/index.html
+++ b/docs/ui/makeup-listbox-button/index.html
@@ -581,6 +581,311 @@
             </div>
           </div>
         </div>
+        <hr />
+        <h2>Example 3: Listbox with group headers</h2>
+        <p>
+          ARROW keys move the active descendant <em>and</em> automatically updated the selected state. The selection
+          moves through groups in the order that the options are rendered in the listbox.
+        </p>
+        <h3>Unselected, Manual Selection</h3>
+        <style>
+          [role="group"] div.listbox-button__option[role="option"] {
+            padding: 8px 30px;
+          }
+          .header-container {
+            background-color: #dadada;
+            font-size: 24px;
+          }
+        </style>
+        <div class="listbox-button" data-makeup-auto-select="false">
+          <button
+            class="btn btn--primary"
+            style="min-width: 175px"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            data-listbox-button-prefix="Color: "
+          >
+            <span class="btn__cell">
+              <span class="btn__text">Color: -</span>
+              <svg class="icon icon--12" focusable="false" height="10" width="14" aria-hidden="true">
+                <use xlink:href="../../static/icons.svg#icon-chevron-down-12"></use>
+              </svg>
+            </span>
+          </button>
+          <div class="listbox-button__listbox" hidden>
+            <div class="listbox-button__options" role="listbox">
+              <div id="warm-color-group-title" role="presentation" class="header-container" style="padding: 8px 15px">
+                <span class="listbox-button_header">Warm Colors</span>
+              </div>
+              <div class="listbox-button__option" aria-describedby="warm-color-group-title" role="option">
+                <span class="listbox-button__value">Red</span>
+                <svg class="icon icon--16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+              <div class="listbox-button__option" aria-describedby="warm-color-group-title" role="option">
+                <span class="listbox-button__value">Orange</span>
+                <svg class="icon icon--16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+              <div
+                class="listbox-button__option"
+                aria-disabled="true"
+                aria-describedby="warm-color-group-title"
+                role="option"
+              >
+                <span class="listbox-button__value">Yellow</span>
+                <svg class="icon icon--16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+              <div id="cool-color-group-title" role="presentation" class="header-container" style="padding: 8px 15px">
+                <span class="listbox-button_header">Cool Colors</span>
+              </div>
+              <div class="listbox-button__option" aria-describedby="cool-color-group-title" role="option">
+                <span class="listbox-button__value">Violet</span>
+                <svg class="icon icon--16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+              <div class="listbox-button__option" aria-describedby="cool-color-group-title" role="option">
+                <span class="listbox-button__value">Blue</span>
+                <svg class="icon icon--16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+              <div class="listbox-button__option" aria-describedby="cool-color-group-title" role="option">
+                <span class="listbox-button__value">Green</span>
+                <svg class="icon icon--16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <h3>Selected, Automatic Selection</h3>
+        <div class="listbox-button" data-makeup-auto-select="true">
+          <button
+            class="btn btn--primary"
+            style="min-width: 175px"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            data-listbox-button-prefix="Color: "
+          >
+            <span class="btn__cell">
+              <span class="btn__text">Color: -</span>
+              <svg class="icon icon--12" focusable="false" height="10" width="14" aria-hidden="true">
+                <use xlink:href="../../static/icons.svg#icon-chevron-down-12"></use>
+              </svg>
+            </span>
+          </button>
+          <div class="listbox-button__listbox" hidden>
+            <div class="listbox-button__options" role="listbox">
+              <div id="warm-color-group-title" role="presentation" class="header-container" style="padding: 8px 15px">
+                <span class="listbox-button_header">Warm Colors</span>
+              </div>
+              <div
+                class="listbox-button__option"
+                aria-describedby="warm-color-group-title"
+                role="option"
+                aria-selected="true"
+              >
+                <span class="listbox-button__value">Red</span>
+                <span class="listbox-button__description">
+                  <span class="clipped" aria-hidden="true">Clipped Text</span>
+                  More information about Red
+                </span>
+                <svg class="icon icon--16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+              <div class="listbox-button__option" aria-describedby="warm-color-group-title" role="option">
+                <span class="listbox-button__value">Orange</span>
+                <span class="listbox-button__description">
+                  <span class="clipped" aria-hidden="true">.</span>
+                  More information about Orange
+                </span>
+                <svg class="icon icon--16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+              <div
+                class="listbox-button__option"
+                aria-disabled="true"
+                aria-describedby="warm-color-group-title"
+                role="option"
+              >
+                <span class="listbox-button__value">Yellow</span>
+                <span class="listbox-button__description">
+                  <span class="clipped" aria-hidden="true">Clipped Text</span>
+                  More information about Yellow
+                </span>
+                <svg class="icon icon--16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+
+              <div id="cool-color-group-title" role="presentation" class="header-container" style="padding: 8px 15px">
+                <span class="listbox-button_header">Cool Colors</span>
+              </div>
+              <div class="listbox-button__option" aria-describedby="cool-color-group-title" role="option">
+                <span class="listbox-button__value">Violet</span>
+                <span class="listbox-button__description">
+                  <span class="clipped" aria-hidden="true">.</span>
+                  More information about Violet
+                </span>
+                <svg class="icon icon--16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+              <div
+                class="listbox-button__option"
+                aria-describedby="cool-color-group-title"
+                role="option"
+                aria-selected="false"
+              >
+                <span class="listbox-button__value">Blue</span>
+                <span class="listbox-button__description">
+                  <span class="clipped" aria-hidden="true">Clipped Text</span>
+                  More information about Blue
+                </span>
+                <svg class="icon icon--16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+              <div class="listbox-button__option" aria-describedby="cool-color-group-title" role="option">
+                <span class="listbox-button__value">Green</span>
+                <span class="listbox-button__description">
+                  <span class="clipped" aria-hidden="true">.</span>
+                  More information about Green
+                </span>
+                <svg class="icon icon--16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+        <h3>Presented as columns, AutoSelect, Selected</h3>
+        <style>
+          .column-container {
+            width: 300px;
+          }
+          .column-container [role="listbox"] {
+            display: flex;
+          }
+
+          .column-container .column {
+            display: flex;
+            flex-direction: column;
+            flex-basis: 50%;
+          }
+          .column-container .column:first-of-type {
+            border-right: 1px solid #9a9a9a;
+          }
+        </style>
+        <div class="listbox-button" data-makeup-auto-select="true">
+          <button
+            class="btn btn--primary"
+            style="min-width: 175px"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            data-listbox-button-prefix="Color: "
+          >
+            <span class="btn__cell">
+              <span class="btn__text">Color: -</span>
+              <svg class="icon icon--12" focusable="false" height="10" width="14" aria-hidden="true">
+                <use xlink:href="../../static/icons.svg#icon-chevron-down-12"></use>
+              </svg>
+            </span>
+          </button>
+          <div class="listbox-button__listbox column-container" hidden>
+            <div class="listbox-button__options" role="listbox">
+              <div class="column">
+                <div id="warm-color-group-title" role="presentation" class="header-container" style="padding: 8px 15px">
+                  <span class="listbox-button_header">Warm Colors</span>
+                </div>
+                <div
+                  class="listbox-button__option"
+                  aria-describedby="warm-color-group-title"
+                  role="option"
+                  aria-selected="true"
+                >
+                  <span class="listbox-button__value">Red</span>
+                  <span class="listbox-button__description">
+                    <span class="clipped" aria-hidden="true">Clipped Text</span>
+                    More information about Red
+                  </span>
+                  <svg class="icon icon--16" focusable="false" height="10" width="14">
+                    <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                  </svg>
+                </div>
+                <div class="listbox-button__option" aria-describedby="warm-color-group-title" role="option">
+                  <span class="listbox-button__value">Orange</span>
+                  <span class="listbox-button__description">
+                    <span class="clipped" aria-hidden="true">.</span>
+                    More information about Orange
+                  </span>
+                  <svg class="icon icon--16" focusable="false" height="10" width="14">
+                    <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                  </svg>
+                </div>
+                <div
+                  class="listbox-button__option"
+                  aria-disabled="true"
+                  aria-describedby="warm-color-group-title"
+                  role="option"
+                >
+                  <span class="listbox-button__value">Yellow</span>
+                  <span class="listbox-button__description">
+                    <span class="clipped" aria-hidden="true">Clipped Text</span>
+                    More information about Yellow
+                  </span>
+                  <svg class="icon icon--16" focusable="false" height="10" width="14">
+                    <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                  </svg>
+                </div>
+              </div>
+              <div class="column">
+                <div id="cool-color-group-title" role="presentation" class="header-container" style="padding: 8px 15px">
+                  <span class="listbox-button_header">Cool Colors</span>
+                </div>
+                <div class="listbox-button__option" aria-describedby="cool-color-group-title" role="option">
+                  <span class="listbox-button__value">Violet</span>
+                  <span class="listbox-button__description">
+                    <span class="clipped" aria-hidden="true">.</span>
+                    More information about Violet
+                  </span>
+                  <svg class="icon icon--16" focusable="false" height="10" width="14">
+                    <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                  </svg>
+                </div>
+                <div class="listbox-button__option" aria-describedby="cool-color-group-title" role="option">
+                  <span class="listbox-button__value">Blue</span>
+                  <span class="listbox-button__description">
+                    <span class="clipped" aria-hidden="true">Clipped Text</span>
+                    More information about Blue
+                  </span>
+                  <svg class="icon icon--16" focusable="false" height="10" width="14">
+                    <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                  </svg>
+                </div>
+                <div class="listbox-button__option" aria-describedby="cool-color-group-title" role="option">
+                  <span class="listbox-button__value">Green</span>
+                  <span class="listbox-button__description">
+                    <span class="clipped" aria-hidden="true">.</span>
+                    More information about Green
+                  </span>
+                  <svg class="icon icon--16" focusable="false" height="10" width="14">
+                    <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                  </svg>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </main>
     </div>
     <script src="index.min.js"></script>

--- a/docs/ui/makeup-listbox-button/index.html
+++ b/docs/ui/makeup-listbox-button/index.html
@@ -173,7 +173,83 @@
             </div>
           </div>
         </div>
-
+        <h3>With Group Labels</h3>
+        <style>
+          [role="group"] div.listbox-button__option[role="option"] {
+            padding: 8px 30px;
+          }
+          .header-container {
+            background-color: #dadada;
+            font-size: 24px;
+          }
+        </style>
+        <div class="listbox-button" data-makeup-auto-select="false">
+          <button
+            class="btn btn--form"
+            style="min-width: 175px"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            data-listbox-button-prefix="Color: "
+          >
+            <span class="btn__cell">
+              <span class="btn__text">Color: </span>
+              <svg class="icon icon--chevron-down-12" focusable="false" height="10" width="14" aria-hidden="true">
+                <use href="../../icons.svg#icon-chevron-down-12"></use>
+              </svg>
+            </span>
+          </button>
+          <div class="listbox-button__listbox" hidden>
+            <div class="listbox-button__options" role="listbox">
+              <div id="warm-color-group-title" role="presentation" class="header-container" style="padding: 8px 15px">
+                <span class="listbox-button_header">Warm Colors</span>
+              </div>
+              <div class="listbox-button__option" aria-describedby="warm-color-group-title" role="option">
+                <span class="listbox-button__value">Red</span>
+                <svg class="icon icon--16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+              <div class="listbox-button__option" aria-describedby="warm-color-group-title" role="option">
+                <span class="listbox-button__value">Orange</span>
+                <svg class="icon icon--16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+              <div
+                class="listbox-button__option"
+                aria-disabled="true"
+                aria-describedby="warm-color-group-title"
+                role="option"
+              >
+                <span class="listbox-button__value">Yellow</span>
+                <svg class="icon icon--16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+              <div id="cool-color-group-title" role="presentation" class="header-container" style="padding: 8px 15px">
+                <span class="listbox-button_header">Cool Colors</span>
+              </div>
+              <div class="listbox-button__option" aria-describedby="cool-color-group-title" role="option">
+                <span class="listbox-button__value">Violet</span>
+                <svg class="icon icon--16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+              <div class="listbox-button__option" aria-describedby="cool-color-group-title" role="option">
+                <span class="listbox-button__value">Blue</span>
+                <svg class="icon icon--16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+              <div class="listbox-button__option" aria-describedby="cool-color-group-title" role="option">
+                <span class="listbox-button__value">Green</span>
+                <svg class="icon icon--16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
         <h2>Automatic Selection</h2>
         <p>
           ARROW keys move the active descendant <em>and</em> automatically updated the selected state. This behaviour is
@@ -581,103 +657,20 @@
             </div>
           </div>
         </div>
-        <hr />
-        <h2>Example 3: Listbox with group headers</h2>
-        <p>
-          ARROW keys move the active descendant <em>and</em> automatically updated the selected state. The selection
-          moves through groups in the order that the options are rendered in the listbox.
-        </p>
-        <h3>Unselected, Manual Selection</h3>
-        <style>
-          [role="group"] div.listbox-button__option[role="option"] {
-            padding: 8px 30px;
-          }
-          .header-container {
-            background-color: #dadada;
-            font-size: 24px;
-          }
-        </style>
-        <div class="listbox-button" data-makeup-auto-select="false">
-          <button
-            class="btn btn--primary"
-            style="min-width: 175px"
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            data-listbox-button-prefix="Color: "
-          >
-            <span class="btn__cell">
-              <span class="btn__text">Color: -</span>
-              <svg class="icon icon--12" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../../static/icons.svg#icon-chevron-down-12"></use>
-              </svg>
-            </span>
-          </button>
-          <div class="listbox-button__listbox" hidden>
-            <div class="listbox-button__options" role="listbox">
-              <div id="warm-color-group-title" role="presentation" class="header-container" style="padding: 8px 15px">
-                <span class="listbox-button_header">Warm Colors</span>
-              </div>
-              <div class="listbox-button__option" aria-describedby="warm-color-group-title" role="option">
-                <span class="listbox-button__value">Red</span>
-                <svg class="icon icon--16" focusable="false" height="10" width="14">
-                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
-                </svg>
-              </div>
-              <div class="listbox-button__option" aria-describedby="warm-color-group-title" role="option">
-                <span class="listbox-button__value">Orange</span>
-                <svg class="icon icon--16" focusable="false" height="10" width="14">
-                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
-                </svg>
-              </div>
-              <div
-                class="listbox-button__option"
-                aria-disabled="true"
-                aria-describedby="warm-color-group-title"
-                role="option"
-              >
-                <span class="listbox-button__value">Yellow</span>
-                <svg class="icon icon--16" focusable="false" height="10" width="14">
-                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
-                </svg>
-              </div>
-              <div id="cool-color-group-title" role="presentation" class="header-container" style="padding: 8px 15px">
-                <span class="listbox-button_header">Cool Colors</span>
-              </div>
-              <div class="listbox-button__option" aria-describedby="cool-color-group-title" role="option">
-                <span class="listbox-button__value">Violet</span>
-                <svg class="icon icon--16" focusable="false" height="10" width="14">
-                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
-                </svg>
-              </div>
-              <div class="listbox-button__option" aria-describedby="cool-color-group-title" role="option">
-                <span class="listbox-button__value">Blue</span>
-                <svg class="icon icon--16" focusable="false" height="10" width="14">
-                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
-                </svg>
-              </div>
-              <div class="listbox-button__option" aria-describedby="cool-color-group-title" role="option">
-                <span class="listbox-button__value">Green</span>
-                <svg class="icon icon--16" focusable="false" height="10" width="14">
-                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
-                </svg>
-              </div>
-            </div>
-          </div>
-        </div>
 
-        <h3>Selected, Automatic Selection</h3>
+        <h3>With Group Labels and description</h3>
         <div class="listbox-button" data-makeup-auto-select="true">
           <button
-            class="btn btn--primary"
+            class="btn btn--form"
             style="min-width: 175px"
             aria-expanded="false"
             aria-haspopup="listbox"
             data-listbox-button-prefix="Color: "
           >
             <span class="btn__cell">
-              <span class="btn__text">Color: -</span>
-              <svg class="icon icon--12" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../../static/icons.svg#icon-chevron-down-12"></use>
+              <span class="btn__text">Color: Red</span>
+              <svg class="icon icon--chevron-down-12" focusable="false" height="10" width="14" aria-hidden="true">
+                <use href="../../icons.svg#icon-chevron-down-12"></use>
               </svg>
             </span>
           </button>
@@ -768,7 +761,7 @@
             </div>
           </div>
         </div>
-        <h3>Presented as columns, AutoSelect, Selected</h3>
+        <h3>With Group Labels and description, Presented as columns</h3>
         <style>
           .column-container {
             width: 300px;
@@ -788,16 +781,16 @@
         </style>
         <div class="listbox-button" data-makeup-auto-select="true">
           <button
-            class="btn btn--primary"
+            class="btn btn--form"
             style="min-width: 175px"
             aria-expanded="false"
             aria-haspopup="listbox"
             data-listbox-button-prefix="Color: "
           >
             <span class="btn__cell">
-              <span class="btn__text">Color: -</span>
-              <svg class="icon icon--12" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="../../static/icons.svg#icon-chevron-down-12"></use>
+              <span class="btn__text">Color: Red</span>
+              <svg class="icon icon--chevron-down-12" focusable="false" height="10" width="14" aria-hidden="true">
+                <use href="../../icons.svg#icon-chevron-down-12"></use>
               </svg>
             </span>
           </button>

--- a/docs/ui/makeup-listbox/index.html
+++ b/docs/ui/makeup-listbox/index.html
@@ -94,6 +94,70 @@
           </div>
         </div>
 
+        <h3>Unselected, With Group Labels</h3>
+        <style>
+          div.listbox__option[role="option"],
+          [role="presentation"] {
+            padding: 8px 15px;
+          }
+          .header-container {
+            background-color: #dadada;
+            font-size: 24px;
+          }
+        </style>
+        <div class="listbox" data-makeup-auto-select="false">
+          <div aria-label="Color" class="listbox__options" role="listbox" tabindex="0">
+            <div id="warm-color-group-title" class="header-container" role="presentation">
+              <span class="listbox__header">Warm Colors</span>
+            </div>
+            <div class="listbox__option" role="option" aria-describedby="warm-color-group-title" aria-selected="false">
+              <span class="listbox__value">Red</span>
+              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                <use xlink:href="../../icons.svg#icon-tick-16"></use>
+              </svg>
+            </div>
+            <div class="listbox__option" role="option" aria-describedby="warm-color-group-title" aria-selected="false">
+              <span class="listbox__value">Orange</span>
+              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                <use xlink:href="../../icons.svg#icon-tick-16"></use>
+              </svg>
+            </div>
+            <div
+              class="listbox__option"
+              role="option"
+              aria-describedby="warm-color-group-title"
+              aria-selected="false"
+              aria-disabled="true"
+            >
+              <span class="listbox__value">Yellow</span>
+              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                <use xlink:href="../../icons.svg#icon-tick-16"></use>
+              </svg>
+            </div>
+            <div id="cool-color-group-title" class="header-container" role="presentation">
+              <span class="listbox__header">Cool Colors</span>
+            </div>
+            <div class="listbox__option" aria-describedby="cool-color-group-title" role="option" aria-selected="false">
+              <span class="listbox__value">Blue</span>
+              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                <use xlink:href="../../icons.svg#icon-tick-16"></use>
+              </svg>
+            </div>
+            <div class="listbox__option" aria-describedby="cool-color-group-title" role="option" aria-selected="false">
+              <span class="listbox__value">Green </span>
+              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                <use xlink:href="../../icons.svg#icon-tick-16"></use>
+              </svg>
+            </div>
+            <div class="listbox__option" aria-describedby="cool-color-group-title" role="option" aria-selected="false">
+              <span class="listbox__value">Violet</span>
+              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                <use xlink:href="../../icons.svg#icon-tick-16"></use>
+              </svg>
+            </div>
+          </div>
+        </div>
+
         <h2>Automatic Selection</h2>
         <p>
           ARROW keys move the active descendant <em>and</em> automatically updated the selected state. This behaviour is
@@ -242,77 +306,7 @@
             </div>
           </div>
         </div>
-        <hr />
-        <h2>Example 3: Listbox with group headers</h2>
-        <p>
-          ARROW keys move the active descendant <em>and</em> automatically updated the selected state. The selection
-          moves through groups in the order that the options are rendered in the listbox.
-        </p>
-        <h3>Unselected, Manual Selection</h3>
-        <style>
-          div.listbox__option[role="option"],
-          [role="presentation"] {
-            padding: 8px 15px;
-          }
-          .header-container {
-            background-color: #dadada;
-            font-size: 24px;
-          }
-        </style>
-
-        <div class="listbox" data-makeup-auto-select="false">
-          <div aria-label="Color" class="listbox__options" role="listbox" tabindex="0">
-            <div id="warm-color-group-title" class="header-container" role="presentation">
-              <span class="listbox__header">Warm Colors</span>
-            </div>
-            <div class="listbox__option" role="option" aria-describedby="warm-color-group-title" aria-selected="false">
-              <span class="listbox__value">Red</span>
-              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                <use xlink:href="../../icons.svg#icon-tick-16"></use>
-              </svg>
-            </div>
-            <div class="listbox__option" role="option" aria-describedby="warm-color-group-title" aria-selected="false">
-              <span class="listbox__value">Orange</span>
-              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                <use xlink:href="../../icons.svg#icon-tick-16"></use>
-              </svg>
-            </div>
-            <div
-              class="listbox__option"
-              role="option"
-              aria-describedby="warm-color-group-title"
-              aria-selected="false"
-              aria-disabled="true"
-            >
-              <span class="listbox__value">Yellow</span>
-              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                <use xlink:href="../../icons.svg#icon-tick-16"></use>
-              </svg>
-            </div>
-            <div id="cool-color-group-title" class="header-container" role="presentation">
-              <span class="listbox__header">Cool Colors</span>
-            </div>
-            <div class="listbox__option" aria-describedby="cool-color-group-title" role="option" aria-selected="false">
-              <span class="listbox__value">Blue</span>
-              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                <use xlink:href="../../icons.svg#icon-tick-16"></use>
-              </svg>
-            </div>
-            <div class="listbox__option" aria-describedby="cool-color-group-title" role="option" aria-selected="false">
-              <span class="listbox__value">Green </span>
-              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                <use xlink:href="../../icons.svg#icon-tick-16"></use>
-              </svg>
-            </div>
-            <div class="listbox__option" aria-describedby="cool-color-group-title" role="option" aria-selected="false">
-              <span class="listbox__value">Violet</span>
-              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
-                <use xlink:href="../../icons.svg#icon-tick-16"></use>
-              </svg>
-            </div>
-          </div>
-        </div>
-        <h3>Selected, Automatic Selection</h3>
+        <h3>With description and Group Labels</h3>
         <div class="listbox" data-makeup-auto-select="true">
           <div aria-label="Color" class="listbox__options" role="listbox" tabindex="0">
             <div id="warm-color-group-title" class="header-container" role="presentation">
@@ -389,7 +383,8 @@
             </div>
           </div>
         </div>
-        <h3>Presented as columns, Selected, Automatic Selection</h3>
+
+        <h3>Presented as columns, With description and Group Labels</h3>
         <style>
           .column-container {
             width: 300px;

--- a/docs/ui/makeup-listbox/index.html
+++ b/docs/ui/makeup-listbox/index.html
@@ -34,9 +34,7 @@
       <main>
         <h2>Manual Selection</h2>
         <p>ARROW keys move the active descendant. SPACEBAR key is required to manually change the selected state.</p>
-
         <h3>Unselected</h3>
-
         <div class="listbox" data-makeup-auto-select="false">
           <div aria-label="Color" class="listbox__options" role="listbox" tabindex="0">
             <div class="listbox__option" role="option" aria-selected="false">
@@ -67,7 +65,6 @@
         </div>
 
         <h3>Selected</h3>
-
         <div class="listbox" data-makeup-auto-select="false">
           <div aria-label="Color" class="listbox__options" role="listbox" tabindex="0">
             <div class="listbox__option" role="option" aria-selected="false">
@@ -242,6 +239,270 @@
               <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
                 <use href="../../icons.svg#icon-tick-16"></use>
               </svg>
+            </div>
+          </div>
+        </div>
+        <hr />
+        <h2>Example 3: Listbox with group headers</h2>
+        <p>
+          ARROW keys move the active descendant <em>and</em> automatically updated the selected state. The selection
+          moves through groups in the order that the options are rendered in the listbox.
+        </p>
+        <h3>Unselected, Manual Selection</h3>
+        <style>
+          div.listbox__option[role="option"],
+          [role="presentation"] {
+            padding: 8px 15px;
+          }
+          .header-container {
+            background-color: #dadada;
+            font-size: 24px;
+          }
+        </style>
+
+        <div class="listbox" data-makeup-auto-select="false">
+          <div aria-label="Color" class="listbox__options" role="listbox" tabindex="0">
+            <div id="warm-color-group-title" class="header-container" role="presentation">
+              <span class="listbox__header">Warm Colors</span>
+            </div>
+            <div class="listbox__option" role="option" aria-describedby="warm-color-group-title" aria-selected="false">
+              <span class="listbox__value">Red</span>
+              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                <use xlink:href="../../icons.svg#icon-tick-16"></use>
+              </svg>
+            </div>
+            <div class="listbox__option" role="option" aria-describedby="warm-color-group-title" aria-selected="false">
+              <span class="listbox__value">Orange</span>
+              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                <use xlink:href="../../icons.svg#icon-tick-16"></use>
+              </svg>
+            </div>
+            <div
+              class="listbox__option"
+              role="option"
+              aria-describedby="warm-color-group-title"
+              aria-selected="false"
+              aria-disabled="true"
+            >
+              <span class="listbox__value">Yellow</span>
+              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                <use xlink:href="../../icons.svg#icon-tick-16"></use>
+              </svg>
+            </div>
+            <div id="cool-color-group-title" class="header-container" role="presentation">
+              <span class="listbox__header">Cool Colors</span>
+            </div>
+            <div class="listbox__option" aria-describedby="cool-color-group-title" role="option" aria-selected="false">
+              <span class="listbox__value">Blue</span>
+              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                <use xlink:href="../../icons.svg#icon-tick-16"></use>
+              </svg>
+            </div>
+            <div class="listbox__option" aria-describedby="cool-color-group-title" role="option" aria-selected="false">
+              <span class="listbox__value">Green </span>
+              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                <use xlink:href="../../icons.svg#icon-tick-16"></use>
+              </svg>
+            </div>
+            <div class="listbox__option" aria-describedby="cool-color-group-title" role="option" aria-selected="false">
+              <span class="listbox__value">Violet</span>
+              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                <use xlink:href="../../icons.svg#icon-tick-16"></use>
+              </svg>
+            </div>
+          </div>
+        </div>
+        <h3>Selected, Automatic Selection</h3>
+        <div class="listbox" data-makeup-auto-select="true">
+          <div aria-label="Color" class="listbox__options" role="listbox" tabindex="0">
+            <div id="warm-color-group-title" class="header-container" role="presentation">
+              <span class="listbox__header">Warm Colors</span>
+            </div>
+            <div class="listbox__option" role="option" aria-describedby="warm-color-group-title" aria-selected="true">
+              <span class="listbox__value">Red</span>
+              <span class="listbox__description">
+                <span class="clipped" aria-hidden="true">Clipped Text</span>
+                More information about Red
+              </span>
+              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                <use xlink:href="../../icons.svg#icon-tick-16"></use>
+              </svg>
+            </div>
+            <div class="listbox__option" role="option" aria-describedby="warm-color-group-title" aria-selected="false">
+              <span class="listbox__value">Orange</span>
+              <span class="listbox__description">
+                <span class="clipped" aria-hidden="true">.</span>
+                More information about Orange
+              </span>
+              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                <use xlink:href="../../icons.svg#icon-tick-16"></use>
+              </svg>
+            </div>
+            <div
+              class="listbox__option"
+              role="option"
+              aria-describedby="warm-color-group-title"
+              aria-selected="false"
+              aria-disabled="true"
+            >
+              <span class="listbox__value">Yellow</span>
+              <span class="listbox__description">
+                <span class="clipped" aria-hidden="true">Clipped Text</span>
+                More information about Yellow
+              </span>
+              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                <use xlink:href="../../icons.svg#icon-tick-16"></use>
+              </svg>
+            </div>
+            <div id="cool-color-group-title" class="header-container" role="presentation">
+              <span class="listbox__header">Cool Colors</span>
+            </div>
+            <div class="listbox__option" aria-describedby="cool-color-group-title" role="option" aria-selected="false">
+              <span class="listbox__value">Blue</span>
+              <span class="listbox__description">
+                <span class="clipped" aria-hidden="true">Clipped Text</span>
+                More information about Blue
+              </span>
+              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                <use xlink:href="../../icons.svg#icon-tick-16"></use>
+              </svg>
+            </div>
+            <div class="listbox__option" aria-describedby="cool-color-group-title" role="option" aria-selected="false">
+              <span class="listbox__value">Green </span>
+              <span class="listbox__description">
+                <span class="clipped" aria-hidden="true">.</span>
+                More information about Green
+              </span>
+              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                <use xlink:href="../../icons.svg#icon-tick-16"></use>
+              </svg>
+            </div>
+            <div class="listbox__option" aria-describedby="cool-color-group-title" role="option" aria-selected="false">
+              <span class="listbox__value">Violet</span>
+              <span class="listbox__description">
+                <span class="clipped" aria-hidden="true">Clipped Text</span>
+                More information about Violet
+              </span>
+              <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                <use xlink:href="../../icons.svg#icon-tick-16"></use>
+              </svg>
+            </div>
+          </div>
+        </div>
+        <h3>Presented as columns, Selected, Automatic Selection</h3>
+        <style>
+          .column-container {
+            width: 300px;
+          }
+          .column-container [role="listbox"] {
+            display: flex;
+          }
+
+          .column-container .column {
+            display: flex;
+            flex-direction: column;
+          }
+          .column-container .column:first-of-type {
+            border-right: 1px solid #9a9a9a;
+          }
+        </style>
+        <div class="listbox column-container" data-makeup-auto-select="true">
+          <div aria-label="Color, Presented as columns" class="listbox__options" role="listbox" tabindex="0">
+            <div class="column">
+              <div id="warm-color-group-title" class="header-container" role="presentation">
+                <span class="listbox__header">Warm Colors</span>
+              </div>
+              <div class="listbox__option" role="option" aria-describedby="warm-color-group-title" aria-selected="true">
+                <span class="listbox__value">Red</span>
+                <span class="listbox__description">
+                  <span class="clipped" aria-hidden="true">Clipped Text</span>
+                  More information about Red
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+              <div
+                class="listbox__option"
+                role="option"
+                aria-describedby="warm-color-group-title"
+                aria-selected="false"
+              >
+                <span class="listbox__value">Orange</span>
+                <span class="listbox__description">
+                  <span class="clipped" aria-hidden="true">.</span>
+                  More information about Orange
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+              <div
+                class="listbox__option"
+                role="option"
+                aria-describedby="warm-color-group-title"
+                aria-selected="false"
+                aria-disabled="true"
+              >
+                <span class="listbox__value">Yellow</span>
+                <span class="listbox__description">
+                  <span class="clipped" aria-hidden="true">.</span>
+                  More information about Yellow
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+            </div>
+            <div class="column">
+              <div id="cool-color-group-title" class="header-container" role="presentation">
+                <span class="listbox__header">Cool Colors</span>
+              </div>
+              <div
+                class="listbox__option"
+                aria-describedby="cool-color-group-title"
+                role="option"
+                aria-selected="false"
+              >
+                <span class="listbox__value">Blue</span>
+                <span class="listbox__description">
+                  <span class="clipped" aria-hidden="true">Clipped Text</span>
+                  More information about Blue
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+              <div
+                class="listbox__option"
+                aria-describedby="cool-color-group-title"
+                role="option"
+                aria-selected="false"
+              >
+                <span class="listbox__value">Green</span>
+                <span class="listbox__description">
+                  <span class="clipped" aria-hidden="true">.</span>
+                  More information about Green
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
+              <div
+                class="listbox__option"
+                aria-describedby="cool-color-group-title"
+                role="option"
+                aria-selected="false"
+              >
+                <span class="listbox__value">Violet</span>
+                <span class="listbox__description">
+                  <span class="clipped" aria-hidden="true">Clipped Text</span>
+                  More information about Violet
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                  <use xlink:href="../../icons.svg#icon-tick-16"></use>
+                </svg>
+              </div>
             </div>
           </div>
         </div>

--- a/packages/ui/makeup-listbox-button/test/index.spec.js
+++ b/packages/ui/makeup-listbox-button/test/index.spec.js
@@ -190,3 +190,139 @@ test.describe("given a listbox-button for automatic selection", function () {
     });
   });
 });
+
+test.describe("given a listbox-button for automatic selection with grouped headers", function () {
+  let containerEl;
+  let hostBtn;
+  let contentEl;
+  let OptionsEl;
+  let firstOptionEl;
+  let secondOptionEl;
+  let thirdOptionEl;
+  let fourthOptionEl;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/ui/makeup-listbox-button/index.html");
+  });
+
+  test.describe("for unselected, manual selection variant", async function () {
+    test.beforeEach(async ({ page }) => {
+      containerEl = page.locator(".listbox-button").nth(10);
+      hostBtn = containerEl.locator("button");
+      contentEl = containerEl.locator(".listbox-button__listbox");
+      OptionsEl = contentEl.locator(".listbox-button__options");
+      firstOptionEl = contentEl.locator(".listbox-button__option").first();
+      secondOptionEl = contentEl.locator(".listbox-button__option").nth(1);
+    });
+    test("should have the correct initial state", async function () {
+      expect(containerEl).toBeTruthy();
+      await expect(hostBtn).toHaveAttribute("aria-haspopup", "listbox");
+      await expect(hostBtn).toHaveAttribute("aria-expanded", "false");
+      await expect(contentEl).not.toBeVisible();
+      await expect(OptionsEl).toHaveAttribute("role", "listbox");
+      await expect(firstOptionEl).toHaveAttribute("role", "option");
+    });
+
+    test("should expand on host click", async function () {
+      await hostBtn.click();
+      await expect(hostBtn).toHaveAttribute("aria-expanded", "true");
+      await expect(contentEl).toBeVisible();
+    });
+
+    test("should close on host clicking twice", async function () {
+      await hostBtn.click();
+      await expect(hostBtn).toHaveAttribute("aria-expanded", "true");
+      await expect(contentEl).toBeVisible();
+      await hostBtn.click();
+      await expect(hostBtn).toHaveAttribute("aria-expanded", "false");
+      await expect(contentEl).not.toBeVisible();
+    });
+
+    test("should use valid aria on selection", async function () {
+      await hostBtn.click();
+      await expect(secondOptionEl).toBeVisible();
+      await secondOptionEl.click();
+      await expect(secondOptionEl).toHaveAttribute("aria-selected", "true");
+    });
+
+    test("should not expand on host focus", async function () {
+      await hostBtn.focus();
+      await expect(hostBtn).toHaveAttribute("aria-expanded", "false");
+    });
+
+    test("should expand on host using kb [space] key", async function () {
+      await hostBtn.focus();
+      await hostBtn.press("Space");
+      await expect(hostBtn).toHaveAttribute("aria-expanded", "true");
+    });
+
+    test("should expand on host using kb [enter] key", async function () {
+      await hostBtn.focus();
+      await hostBtn.press("Enter");
+      await expect(hostBtn).toHaveAttribute("aria-expanded", "true");
+    });
+
+    test("should dismiss content on [escape] key", async function () {
+      await hostBtn.focus();
+      await hostBtn.press("Space");
+      await hostBtn.press("Escape");
+      await expect(hostBtn).toHaveAttribute("aria-expanded", "false");
+    });
+
+    test("should not focus on disabled option", async function () {
+      const disabledOptionEl = await contentEl.locator(".listbox-button__option[aria-disabled='true']").first();
+      await expect(disabledOptionEl).not.toBeFocused();
+    });
+  });
+
+  test.describe("for selected, automatic selection variant", async function () {
+    test.beforeEach(async ({ page }) => {
+      containerEl = page.locator(".listbox-button").nth(11);
+      hostBtn = containerEl.locator("button");
+      contentEl = containerEl.locator(".listbox-button__listbox");
+      OptionsEl = contentEl.locator(".listbox-button__options");
+      firstOptionEl = OptionsEl.locator(".listbox-button__option").first();
+      secondOptionEl = OptionsEl.locator(".listbox-button__option").nth(1);
+      thirdOptionEl = OptionsEl.locator(".listbox-button__option").nth(2);
+      fourthOptionEl = OptionsEl.locator(".listbox-button__option").nth(3);
+    });
+    test("first option should be automatically selected ", async function () {
+      await expect(firstOptionEl).toHaveAttribute("aria-selected", "true");
+      await hostBtn.click();
+      await expect(secondOptionEl).toBeVisible();
+      await secondOptionEl.click();
+      await expect(secondOptionEl).toHaveAttribute("aria-selected", "true");
+    });
+    test("should auto select using kb arrow down", async function () {
+      await hostBtn.focus();
+      await hostBtn.press("Space");
+      await expect(contentEl).toBeVisible();
+      await expect(hostBtn).toHaveAttribute("aria-expanded", "true");
+      await contentEl.press("ArrowDown");
+      await expect(secondOptionEl).toHaveAttribute("aria-selected", "true");
+    });
+  });
+
+  test.describe("for selected auto select options, presented as columns", async function () {
+    test.beforeEach(async ({ page }) => {
+      containerEl = page.locator(".listbox-button").nth(12);
+      hostBtn = containerEl.locator("button");
+      contentEl = containerEl.locator(".listbox-button__listbox");
+      OptionsEl = contentEl.locator(".listbox-button__options");
+      firstOptionEl = OptionsEl.locator(".listbox-button__option").first();
+      secondOptionEl = OptionsEl.locator(".listbox-button__option").nth(1);
+      thirdOptionEl = OptionsEl.locator(".listbox-button__option").nth(2);
+      fourthOptionEl = OptionsEl.locator(".listbox-button__option").nth(3);
+    });
+    test("disabled options are skipped and navigation moves within columns ", async function () {
+      await hostBtn.focus();
+      await hostBtn.press("Space");
+      await expect(contentEl).toBeVisible();
+      await expect(hostBtn).toHaveAttribute("aria-expanded", "true");
+      await contentEl.press("ArrowDown");
+      await contentEl.press("ArrowDown");
+      await expect(thirdOptionEl).not.toHaveAttribute("aria-selected", "true");
+      await expect(fourthOptionEl).toHaveAttribute("aria-selected", "true");
+    });
+  });
+});

--- a/packages/ui/makeup-listbox-button/test/index.spec.js
+++ b/packages/ui/makeup-listbox-button/test/index.spec.js
@@ -110,7 +110,7 @@ test.describe("given a listbox-button for automatic selection", function () {
   test.beforeEach(async ({ page }) => {
     await page.goto("/ui/makeup-listbox-button/index.html");
 
-    containerEl = page.locator(".listbox-button[data-makeup-auto-select='true']").nth(3);
+    containerEl = page.locator(".listbox-button[data-makeup-auto-select='true']").first();
     hostBtn = containerEl.locator("button");
     contentEl = containerEl.locator(".listbox-button__listbox");
     OptionsEl = contentEl.locator(".listbox-button__options");
@@ -207,7 +207,7 @@ test.describe("given a listbox-button for automatic selection with grouped heade
 
   test.describe("for unselected, manual selection variant", async function () {
     test.beforeEach(async ({ page }) => {
-      containerEl = page.locator(".listbox-button").nth(10);
+      containerEl = page.locator(".listbox-button").nth(3);
       hostBtn = containerEl.locator("button");
       contentEl = containerEl.locator(".listbox-button__listbox");
       OptionsEl = contentEl.locator(".listbox-button__options");
@@ -227,15 +227,6 @@ test.describe("given a listbox-button for automatic selection with grouped heade
       await hostBtn.click();
       await expect(hostBtn).toHaveAttribute("aria-expanded", "true");
       await expect(contentEl).toBeVisible();
-    });
-
-    test("should close on host clicking twice", async function () {
-      await hostBtn.click();
-      await expect(hostBtn).toHaveAttribute("aria-expanded", "true");
-      await expect(contentEl).toBeVisible();
-      await hostBtn.click();
-      await expect(hostBtn).toHaveAttribute("aria-expanded", "false");
-      await expect(contentEl).not.toBeVisible();
     });
 
     test("should use valid aria on selection", async function () {

--- a/packages/ui/makeup-listbox/test/index.spec.js
+++ b/packages/ui/makeup-listbox/test/index.spec.js
@@ -89,3 +89,119 @@ test.describe("given a listbox for automatic selection", function () {
     });
   });
 });
+
+test.describe("given a listbox with headers", function () {
+  let containerEl;
+  let OptionsEl;
+  let firstOptionEl;
+  let secondOptionEl;
+  let firstHeaderEl;
+  let secondHeaderEl;
+  let listbox;
+  let fourthElement;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/ui/makeup-listbox/index.html");
+  });
+
+  test.describe("for unselected variant", async function () {
+    test.beforeEach(async ({ page }) => {
+      containerEl = page.locator(".listbox").nth(6);
+      listbox = await containerEl.getByRole("listbox");
+      OptionsEl = containerEl.locator(".listbox__options");
+      firstOptionEl = OptionsEl.getByRole("option").first();
+      secondOptionEl = OptionsEl.getByRole("option").nth(1);
+      firstHeaderEl = containerEl.getByRole("presentation").first();
+      secondHeaderEl = containerEl.getByRole("presentation").nth(1);
+      fourthElement = OptionsEl.getByRole("option").nth(3);
+    });
+
+    test("should have the correct initial state", async function () {
+      expect(containerEl).toBeTruthy();
+      await expect(OptionsEl).toHaveAttribute("role", "listbox");
+      await expect(firstOptionEl).toHaveAttribute("role", "option");
+    });
+
+    test("should use valid aria on selection", async function () {
+      await secondOptionEl.click();
+      await expect(secondOptionEl).toHaveAttribute("aria-selected", "true");
+    });
+
+    test("should auto select using kb arrow down", async function () {
+      await OptionsEl.focus();
+      await firstOptionEl.press("ArrowDown");
+      await expect(secondOptionEl).toHaveAttribute("aria-selected", "false");
+    });
+
+    test("should not focus on disabled option", async function () {
+      const fourthOptionEl = OptionsEl.getByRole("option").nth(3);
+      await OptionsEl.focus();
+      await firstOptionEl.press("ArrowDown");
+      await secondHeaderEl.press("ArrowDown");
+      const disabledOptionEl = await OptionsEl.locator(".listbox__option[aria-disabled='true']").first();
+      await expect(disabledOptionEl).not.toBeFocused();
+      await expect(fourthOptionEl).toHaveClass("listbox__option listbox__option--active");
+    });
+
+    test("should have aria-describedby value that references the header element", async function () {
+      const firstHeaderId = await firstHeaderEl.getAttribute("id");
+      const secondHeaderId = await secondHeaderEl.getAttribute("id");
+      await expect(firstOptionEl).toHaveAttribute("aria-describedby", firstHeaderId);
+      await expect(secondOptionEl).toHaveAttribute("aria-describedby", firstHeaderId);
+      const thirdOptionEl = OptionsEl.getByRole("option").nth(2);
+      await expect(thirdOptionEl).toHaveAttribute("aria-describedby", firstHeaderId);
+      const fourthOptionEl = OptionsEl.getByRole("option").nth(3);
+      await expect(fourthOptionEl).toHaveAttribute("aria-describedby", secondHeaderId);
+      const fifthOptionEl = OptionsEl.getByRole("option").nth(4);
+      await expect(fifthOptionEl).toHaveAttribute("aria-describedby", secondHeaderId);
+      const sixthOptionEl = OptionsEl.getByRole("option").nth(5);
+      await expect(sixthOptionEl).toHaveAttribute("aria-describedby", secondHeaderId);
+    });
+  });
+
+  test.describe("for selected variant with automatic selection for grouped headers", async function () {
+    test.beforeEach(async ({ page }) => {
+      containerEl = page.locator(".listbox").nth(7);
+      listbox = await containerEl.getByRole("listbox");
+      OptionsEl = containerEl.locator(".listbox__options");
+      firstOptionEl = OptionsEl.getByRole("option").first();
+      secondOptionEl = OptionsEl.getByRole("option").nth(1);
+      firstHeaderEl = containerEl.getByRole("presentation").first();
+      secondHeaderEl = containerEl.getByRole("presentation").nth(1);
+      fourthElement = OptionsEl.getByRole("option").nth(3);
+    });
+    test("should use valid aria on selection", async function () {
+      await expect(firstOptionEl).toHaveAttribute("aria-selected", "true");
+      await secondOptionEl.click();
+      await expect(secondOptionEl).toHaveAttribute("aria-selected", "true");
+    });
+
+    test("should auto select using kb arrow down", async function () {
+      await OptionsEl.focus();
+      await firstOptionEl.press("ArrowDown");
+      await expect(secondOptionEl).toHaveAttribute("aria-selected", "true");
+    });
+  });
+
+  test.describe("for listbox options presented as columns", async function () {
+    test.beforeEach(async ({ page }) => {
+      containerEl = page.locator(".listbox").nth(8);
+      listbox = await containerEl.getByRole("listbox");
+      OptionsEl = containerEl.locator(".listbox__options");
+      firstOptionEl = OptionsEl.getByRole("option").first();
+      secondOptionEl = OptionsEl.getByRole("option").nth(1);
+      firstHeaderEl = containerEl.getByRole("presentation").first();
+      secondHeaderEl = containerEl.getByRole("presentation").nth(1);
+      fourthElement = OptionsEl.getByRole("option").nth(3);
+    });
+    test("should auto select using kb arrow down", async function () {
+      await OptionsEl.focus();
+      await OptionsEl.press("ArrowDown");
+      await OptionsEl.press("ArrowDown");
+      fourthElement = OptionsEl.getByRole("option").nth(3);
+      await expect(fourthElement).toHaveAttribute("aria-selected", "true");
+      const fourthElementId = await fourthElement.getAttribute("id");
+      await expect(listbox).toHaveAttribute("aria-activedescendant", fourthElementId);
+    });
+  });
+});

--- a/packages/ui/makeup-listbox/test/index.spec.js
+++ b/packages/ui/makeup-listbox/test/index.spec.js
@@ -59,7 +59,7 @@ test.describe("given a listbox for automatic selection", function () {
   test.beforeEach(async ({ page }) => {
     await page.goto("/ui/makeup-listbox/index.html");
 
-    containerEl = page.locator(".listbox").nth(2);
+    containerEl = page.locator(".listbox").nth(3);
     OptionsEl = containerEl.locator(".listbox__options");
     firstOptionEl = OptionsEl.getByRole("option").first();
     secondOptionEl = OptionsEl.getByRole("option").nth(1);
@@ -106,7 +106,7 @@ test.describe("given a listbox with headers", function () {
 
   test.describe("for unselected variant", async function () {
     test.beforeEach(async ({ page }) => {
-      containerEl = page.locator(".listbox").nth(6);
+      containerEl = page.locator(".listbox").nth(2);
       listbox = await containerEl.getByRole("listbox");
       OptionsEl = containerEl.locator(".listbox__options");
       firstOptionEl = OptionsEl.getByRole("option").first();


### PR DESCRIPTION
## Description
This PR adds examples for `listbox` and `listbox-button` with headers for listbox options.
This PR is related to a similar PR for `ebay-mindpatterns` https://github.com/eBay/mindpatterns/pull/136
The individual options have an `aria-describedby` attribute that refers to the header element so that the option headers are recognized by screen readers.

## Screenshots
<img width="279" alt="Screenshot 2025-04-03 at 1 23 02 PM" src="https://github.com/user-attachments/assets/1068c4c2-db74-4f24-8a50-09140221b69e" />
<img width="489" alt="Screenshot 2025-04-03 at 1 23 15 PM" src="https://github.com/user-attachments/assets/afe2324a-41d8-4fe1-93ee-9d996857ef76" />
<img width="996" alt="Screenshot 2025-04-03 at 1 23 30 PM" src="https://github.com/user-attachments/assets/fe092a20-1ba0-48c2-a1d4-6a200c22cb1b" />
<img width="980" alt="Screenshot 2025-04-03 at 1 23 40 PM" src="https://github.com/user-attachments/assets/8b91cb62-bb4e-48ec-bd02-0d495c2d1cbd" />
<img width="977" alt="Screenshot 2025-04-03 at 1 23 48 PM" src="https://github.com/user-attachments/assets/4ee1ce4b-69ae-48df-8886-6b2f203fd6f9" />

